### PR TITLE
共通のサイドバーを追加

### DIFF
--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -34,7 +34,7 @@ interface NavItem {
     // },
     {
       title: "ログアウト",
-      href: "/logout",
+      href: "/login",
       icon: <LogOut className="h-5 w-5" />,
     },
   ];

--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from "react";
+import { Drawer, Button, Burger } from "@mantine/core";
+import { Menu, House, Video, FileText, User, LogOut } from "lucide-react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+
+interface NavItem {
+    title: string;
+    href: string;
+    icon: React.ReactNode;
+  }
+  
+  const navItems: NavItem[] = [
+    {
+      title: "ホーム",
+      href: "/",
+      icon: <House className="h-5 w-5" />,
+    },
+    // {
+    //   title: "動画一覧",
+    //   href: "/videos",
+    //   icon: <Video className="h-5 w-5" />,
+    // },
+    {
+      title: "資料一覧",
+      href: "/documents",
+      icon: <FileText className="h-5 w-5" />,
+    },
+    // {
+    //   title: "プロフィール",
+    //   href: "/profile",
+    //   //icon: <User className="h-5 w-5" />,
+    // },
+    {
+      title: "ログアウト",
+      href: "/logout",
+      icon: <LogOut className="h-5 w-5" />,
+    },
+  ];
+  
+  export function SideNav() {
+    const pathname = usePathname();
+    const [open, setOpen] = useState(false);
+    
+    return (
+      <>
+
+        {/* ハンバーガーメニュー (モバイル用) */}
+        <Button 
+            variant="subtle" 
+            onClick={() => setOpen(true)} 
+            className="lg:hidden"
+        >
+        <Menu 
+            size={24}
+            className="lg:hidden" 
+        />
+        </Button>
+        
+        {/* モバイル用ハンバーガーメニュー */}
+        <Drawer
+            opened={open}
+            onClose={() => setOpen(false)}
+            position="left"
+            size="250px"
+            padding="md"
+            title="メニュー"
+        >
+            <nav className="space-y-2">
+            {navItems.map((item) => (
+                <Link
+                key={item.href}
+                href={item.href}
+                onClick={() => setOpen(false)}
+                className="flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-all hover:text-foreground"
+                >
+                {item.icon}
+                {item.title}
+                </Link>
+            ))}
+            </nav>
+        </Drawer>
+
+        {/* デスクトップ用サイドバー */}
+        <div className="hidden lg:flex h-screen w-64 flex-col fixed left-0 top-0 border-r bg-card">
+          <div className="p-6">
+            <h1 className="text-xl font-bold">Sinlab Portal</h1>
+          </div>
+          <nav className="flex-1 space-y-2 p-4">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-all hover:text-foreground"
+              >
+                {item.icon}
+                {item.title}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      </>
+    );
+  }

--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { Drawer, Button, Burger } from "@mantine/core";
 import { Menu, House, Video, FileText, User, LogOut } from "lucide-react";
-import { usePathname } from "next/navigation";
 import Link from "next/link";
 
 interface NavItem {
@@ -39,9 +38,8 @@ interface NavItem {
       icon: <LogOut className="h-5 w-5" />,
     },
   ];
-  
+
   export function SideNav() {
-    const pathname = usePathname();
     const [open, setOpen] = useState(false);
     
     return (
@@ -51,11 +49,11 @@ interface NavItem {
         <Button 
             variant="subtle" 
             onClick={() => setOpen(true)} 
-            className="lg:hidden"
+            className="sm:hidden"
         >
         <Menu 
             size={24}
-            className="lg:hidden" 
+            className="sm:hidden" 
         />
         </Button>
         
@@ -74,7 +72,7 @@ interface NavItem {
                 key={item.href}
                 href={item.href}
                 onClick={() => setOpen(false)}
-                className="flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-all hover:text-foreground"
+                className="flex items-center gap-3 rounded-sm px-3 py-2 text-muted-foreground transition-all hover:text-foreground"
                 >
                 {item.icon}
                 {item.title}
@@ -84,7 +82,7 @@ interface NavItem {
         </Drawer>
 
         {/* デスクトップ用サイドバー */}
-        <div className="hidden lg:flex h-screen w-64 flex-col fixed left-0 top-0 border-r bg-card">
+        <div className="hidden sm:flex h-screen w-64 flex-col fixed left-0 top-0 border-r bg-card">
           <div className="p-6">
             <h1 className="text-xl font-bold">Sinlab Portal</h1>
           </div>
@@ -93,7 +91,7 @@ interface NavItem {
               <Link
                 key={item.href}
                 href={item.href}
-                className="flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-all hover:text-foreground"
+                className="flex items-center gap-3 rounded-sm px-3 py-2 text-muted-foreground transition-all hover:text-foreground"
               >
                 {item.icon}
                 {item.title}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "@mantine/core/styles.css";
 import "./globals.css";
 import { ColorSchemeScript, mantineHtmlProps, MantineProvider } from "@mantine/core";
+import { SideNav } from "./components/SideNav";
 
 export const metadata: Metadata = {
   title: "Sinlab Portal",
@@ -28,7 +29,10 @@ export default function RootLayout({
         <ColorSchemeScript />
       </head>
       <body>
-        <MantineProvider>{children}</MantineProvider>
+        <MantineProvider>
+          <SideNav />
+          {children}
+        </MantineProvider>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,8 +30,10 @@ export default function RootLayout({
       </head>
       <body>
         <MantineProvider>
-          <SideNav />
-          {children}
+          <div className="sm:flex min-h-screen">
+            <SideNav />
+            <div className="flex-1 sm:ml-48">{children}</div>
+          </div>
         </MantineProvider>
       </body>
     </html>


### PR DESCRIPTION
## 変更内容

サイドバーを追加しました。

## 関連Issue

https://github.com/Singuralitylabs/portal-site/issues/9

## 特記事項

- モバイル、デスクトップとも問題ないか
- アイコンは lucide-reactから取得しております
- url直下の表示にて、「シンラボ〜です」とメニューが被っているのが大丈夫か、確認お願いします