### PR TITLE
サイドバーにロゴを追加（適切なフォーマット修正戻し含む）

### DIFF
--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import { useState } from "react";
 import { Drawer, Button, Burger } from "@mantine/core";
@@ -6,99 +6,99 @@ import { Menu, House, Video, FileText, User, LogOut } from "lucide-react";
 import Link from "next/link";
 
 interface NavItem {
-    title: string;
-    href: string;
-    icon: React.ReactNode;
-  }
-  
-  const navItems: NavItem[] = [
-    {
-      title: "ホーム",
-      href: "/",
-      icon: <House className="h-5 w-5" />,
-    },
-    // {
-    //   title: "動画一覧",
-    //   href: "/videos",
-    //   icon: <Video className="h-5 w-5" />,
-    // },
-    {
-      title: "資料一覧",
-      href: "/documents",
-      icon: <FileText className="h-5 w-5" />,
-    },
-    // {
-    //   title: "プロフィール",
-    //   href: "/profile",
-    //   //icon: <User className="h-5 w-5" />,
-    // },
-    {
-      title: "ログアウト",
-      href: "/login",
-      icon: <LogOut className="h-5 w-5" />,
-    },
-  ];
+  title: string;
+  href: string;
+  icon: React.ReactNode;
+}
 
-  export function SideNav() {
-    const [open, setOpen] = useState(false);
-    
-    return (
-      <>
+const navItems: NavItem[] = [
+  {
+    title: "ホーム",
+    href: "/",
+    icon: <House className="h-5 w-5" />,
+  },
+  // {
+  //   title: "動画一覧",
+  //   href: "/videos",
+  //   icon: <Video className="h-5 w-5" />,
+  // },
+  {
+    title: "資料一覧",
+    href: "/documents",
+    icon: <FileText className="h-5 w-5" />,
+  },
+  // {
+  //   title: "プロフィール",
+  //   href: "/profile",
+  //   //icon: <User className="h-5 w-5" />,
+  // },
+  {
+    title: "ログアウト",
+    href: "/login",
+    icon: <LogOut className="h-5 w-5" />,
+  },
+];
 
-        {/* ハンバーガーメニュー (モバイル用) */}
-        <Button 
-            variant="subtle" 
-            onClick={() => setOpen(true)} 
-            className="sm:hidden"
-        >
-        <Menu 
-            size={24}
-            className="sm:hidden" 
-        />
-        </Button>
-        
-        {/* モバイル用ハンバーガーメニュー */}
-        <Drawer
-            opened={open}
-            onClose={() => setOpen(false)}
-            position="left"
-            size="250px"
-            padding="md"
-            title="メニュー"
-        >
-            <nav className="space-y-2">
-            {navItems.map((item) => (
-                <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setOpen(false)}
-                className="flex items-center gap-3 rounded-sm px-3 py-2 text-muted-foreground transition-all hover:text-foreground"
-                >
-                {item.icon}
-                {item.title}
-                </Link>
-            ))}
-            </nav>
-        </Drawer>
+export function SideNav() {
+  const [open, setOpen] = useState(false);
 
-        {/* デスクトップ用サイドバー */}
-        <div className="hidden sm:flex h-screen w-64 flex-col fixed left-0 top-0 border-r bg-card">
-          <div className="p-6">
-            <h1 className="text-xl font-bold">Sinlab Portal</h1>
+  return (
+    <>
+      {/* ハンバーガーメニュー (モバイル用) */}
+      <Button variant="subtle" onClick={() => setOpen(true)} className="sm:hidden">
+        <Menu size={24} className="sm:hidden" />
+      </Button>
+
+      {/* モバイル用ハンバーガーメニュー */}
+      <Drawer
+        opened={open}
+        onClose={() => setOpen(false)}
+        position="left"
+        size="250px"
+        padding="md"
+        title={
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <img src="/icon.png" alt="Sinlab Logo" className="w-4 h-4 mr-2" />
+            <div className="font-bold">Sinlab Portal</div>
           </div>
-          <nav className="flex-1 space-y-2 p-4">
-            {navItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="flex items-center gap-3 rounded-sm px-3 py-2 text-muted-foreground transition-all hover:text-foreground"
-              >
-                {item.icon}
-                {item.title}
-              </Link>
-            ))}
-          </nav>
+        }
+      >
+        <nav className="space-y-2">
+          {navItems.map(item => (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-3 rounded-sm px-3 py-2 text-muted-foreground transition-all hover:text-foreground"
+            >
+              {item.icon}
+              {item.title}
+            </Link>
+          ))}
+        </nav>
+      </Drawer>
+
+      {/* デスクトップ用サイドバー */}
+      <div className="hidden sm:flex h-screen w-64 flex-col fixed left-0 top-0 border-r bg-card">
+        <div className="p-6">
+          <h1 className="text-xl font-bold flex items-center space-x-2">
+            <img src="/icon.png" alt="Sinlab Logo" className="w-6 h-6" />
+            <div className="font-bold">Sinlab Portal</div>
+          </h1>
         </div>
-      </>
-    );
-  }
+        <nav className="flex-1 space-y-2 p-4">
+          {navItems.map(item => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="flex items-center gap-3 rounded-sm px-3 py-2 text-muted-foreground transition-all hover:text-foreground"
+            >
+              {item.icon}
+              {item.title}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## 変更内容

- サイドバーにロゴを追加しました
- その際、タイトルに合わせて画像の高さを調整し、PCは "w-6 h-6", モバイルは "w-4 h-4" としています
- npm run build 確認済みです

## 関連Issue

[サイドバーにロゴ追加](https://github.com/Singuralitylabs/portal-site/issues/31)

## 特記事項

- フォーマットが効かず反映されていない件、設定を見直して見直してみましたが、解決できませんでした
  - コードの範囲指定で「ドキュメントのフォーマット」とすると調整されたので、根本解決まで手動フォーマットします
- 見えにくくなって恐縮ですが、以下の部分がロゴによる修正です。
  - モバイル画面：　赤67行目 -> 緑60-63行目
  - PC画面：　赤87行目 -> 緑84-87行目
- PC画面でのみ画像と隙間が見られなかったので、mr-2 (マージン追加) を追加しましたが、揃えたほうがよければモバイル画面でつけて問題ないこと確認する形で、どちらもつける方に揃えます


