### PR TITLE
documentsデータ取得の実装

### DIFF
--- a/app/documents/components/Template .tsx
+++ b/app/documents/components/Template .tsx
@@ -1,0 +1,28 @@
+'use client';
+import { DocumentCard } from './DocumentCard';
+import { Grid, Paper, Title } from '@mantine/core';
+
+import { DocumentType } from '@/app/types';
+
+interface DocumentsPageTemplateProps  {
+    documents: DocumentType[];
+};
+
+export function DocumentsPageTemplate({documents} : DocumentsPageTemplateProps) {
+  return (
+    <Paper m="0 2rem">
+      <Title order={1} p="1.25rem 0" style={{ borderBottom: '1px solid #888' }}>資料一覧</Title>
+
+      <Paper>
+        <Title order={2} p="1rem 0">学習資料</Title>
+        <Grid>
+          {documents.map((document) => (
+            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} key={document.id + '_grid'}>
+              <DocumentCard key={document.id + '_DocumentCard'} document={document} />
+            </Grid.Col>
+          ))}
+        </Grid>
+      </Paper>
+    </Paper>
+  );
+}

--- a/app/documents/components/Template.tsx
+++ b/app/documents/components/Template.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { DocumentCard } from './DocumentCard';
 import { Grid, Paper, Title } from '@mantine/core';
 
@@ -14,11 +15,10 @@ export function DocumentsPageTemplate({documents} : DocumentsPageTemplateProps) 
       <Title order={1} p="1.25rem 0" style={{ borderBottom: '1px solid #888' }}>資料一覧</Title>
 
       <Paper>
-        <Title order={2} p="1rem 0">学習資料</Title>
         <Grid>
           {documents.map((document) => (
             <Grid.Col span={{ base: 12, md: 6, lg: 4 }} key={document.id + '_grid'}>
-              <DocumentCard key={document.id + '_DocumentCard'} document={document} />
+              <DocumentCard document={document} />
             </Grid.Col>
           ))}
         </Grid>

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -5,7 +5,6 @@ export default async function DocumentsPage() {
   const { data, error } = await fetchDocuments();
 
   if (error) {
-    console.error('データ取得エラー:', error);
     return <p>データを取得できませんでした。</p>;
   }
 

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,5 +1,5 @@
 import { fetchDocuments } from '@/app/services/api/documents';
-import { DocumentsPageTemplate } from './components/Template ';
+import { DocumentsPageTemplate } from './components/Template';
 
 export default async function DocumentsPage() {
   const { data, error } = await fetchDocuments();

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,24 +1,13 @@
-'use client';
+import { fetchDocuments } from '@/app/services/api/documents';
+import { DocumentsPageTemplate } from './components/Template ';
 
-import { documents } from '../data/documents';
-import { DocumentCard } from './components/DocumentCard';
-import { Grid, Paper, Title } from '@mantine/core';
+export default async function DocumentsPage() {
+  const { data, error } = await fetchDocuments();
 
-export default function DocumentsPage() {
-  return (
-    <Paper m="0 2rem">
-      <Title order={1} p="1.25rem 0" style={{borderBottom: '1px solid #888'}}>資料一覧</Title>
+  if (error) {
+    console.error('データ取得エラー:', error);
+    return <p>データを取得できませんでした。</p>;
+  }
 
-      <Paper>
-        <Title order={2} p="1rem 0">学習資料</Title>
-        <Grid>
-          {documents.map((document) => (
-            <Grid.Col span={{ base: 12, md: 6, lg: 4 }} key={document.id + '_grid'}>
-              <DocumentCard key={document.id + '_DocumentCard'} document={document} />
-            </Grid.Col>
-          ))}
-        </Grid>
-      </Paper>
-    </Paper>
-  );
+  return <DocumentsPageTemplate documents={data} />;
 }

--- a/app/services/api/documents.ts
+++ b/app/services/api/documents.ts
@@ -1,0 +1,15 @@
+import supabase from './supabase';
+import { DocumentType } from '@/app/types';
+
+// Documentsテーブルからデータを取得する関数
+export async function fetchDocuments() {
+  const { data, error } = await supabase.from('documents').select('*');
+
+  if (error) {
+    console.error('Supabase データ取得エラー:', error.message);
+    return {data: null, error };
+  }
+
+  return { data, error: null };
+
+}

--- a/app/services/api/documents.ts
+++ b/app/services/api/documents.ts
@@ -1,5 +1,4 @@
 import supabase from './supabase';
-import { DocumentType } from '@/app/types';
 
 // Documentsテーブルからデータを取得する関数
 export async function fetchDocuments() {

--- a/app/services/api/supabase.ts
+++ b/app/services/api/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Supabaseクライアントの作成
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+);
+
+export default supabase;


### PR DESCRIPTION
## 変更内容

supabaseからDocumentsを取得して表示する部分の実装を行いました。
supabase実装はservices/apiに記述。


## 関連Issue

## 特記事項

mantineは、SeverComponentで動作不可なため、
API実装をpage.tsxに記述し、component実装をcomponents/Template.tsx以下に分けて実装しました。
※Template.tsxの命名は要検討。命名は、Atomic DesignのTemplateによる。

参照
[mantine: Server components](https://mantine.dev/guides/next/#server-components)

Atomic Design
https://hongo.dev/blog/introduce-atomic-design-as-refactoring/