### PR TITLE
✨ supabaseのセッション変数にclerk_idを保存する処理を追加

### DIFF
--- a/app/services/api/documents.ts
+++ b/app/services/api/documents.ts
@@ -1,14 +1,13 @@
-import supabase from './supabase';
+import { createServerSupabaseClient } from "./supabase";
 
-// Documentsテーブルからデータを取得する関数
 export async function fetchDocuments() {
-  const { data, error } = await supabase.from('documents').select('*');
+  const supabase = await createServerSupabaseClient();
+  const { data, error } = await supabase.from("documents").select("*");
 
   if (error) {
-    console.error('Supabase データ取得エラー:', error.message);
-    return {data: null, error };
+    console.error("Supabase 資料一覧データ取得エラー:", error.message);
+    return { data: null, error };
   }
 
   return { data, error: null };
-
 }

--- a/app/services/api/supabase.ts
+++ b/app/services/api/supabase.ts
@@ -1,9 +1,25 @@
-import { createClient } from '@supabase/supabase-js';
+import { currentUser } from "@clerk/nextjs/server";
+import { createClient } from "@supabase/supabase-js";
 
-// Supabaseクライアントの作成
+export async function createServerSupabaseClient() {
+  const user = await currentUser();
+  const userId = user?.id || "";
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ""
+  );
+
+  if (userId) {
+    await supabase.rpc("set_clerk_user_id", { clerk_id: userId });
+  }
+
+  return supabase;
+}
+
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+  process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ""
 );
 
 export default supabase;


### PR DESCRIPTION
## 変更内容

* Clerkから渡されたIDをsupabaseに渡す処理を追加（supabaseのRLSでのアクセス制御のため）

## 関連Issue

https://github.com/Singuralitylabs/portal-site/issues/47

## 特記事項

* supabaseのサードパーティ認証の追加は有料サービスとなっていたため、便宜的にClerk IDをチェックする処理に変更しました。
* 本修正はsupabaseの[RLS Policies](https://supabase.com/dashboard/project/hcgnztffycyikgezskqo/auth/policies)や[Functions](https://supabase.com/dashboard/project/hcgnztffycyikgezskqo/database/functions)と一緒に見る必要があります。