### PR TITLE
サイドバーに動画一覧を追加

### DIFF
--- a/app/(authenticated)/components/SideNav.tsx
+++ b/app/(authenticated)/components/SideNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Drawer, Button, Burger } from "@mantine/core";
+import { Drawer, Button } from "@mantine/core";
 import { Menu, House, FileVideo, FileText, User, LogOut } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";

--- a/app/(authenticated)/components/SideNav.tsx
+++ b/app/(authenticated)/components/SideNav.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Drawer, Button, Burger } from "@mantine/core";
-import { Menu, House, Video, FileText, User, LogOut } from "lucide-react";
+import { Menu, House, FileVideo, FileText, User, LogOut } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
 import IconImage from "../../../public/icon.png";
@@ -20,11 +20,11 @@ const navItems: NavItem[] = [
     href: "/",
     icon: <House className="h-5 w-5" />,
   },
-  // {
-  //   title: "動画一覧",
-  //   href: "/videos",
-  //   icon: <Video className="h-5 w-5" />,
-  // },
+  {
+    title: "動画一覧",
+    href: "/movies",
+    icon: <FileVideo className="h-5 w-5" />,
+  },
   {
     title: "資料一覧",
     href: "/documents",

--- a/app/(authenticated)/components/SideNav.tsx
+++ b/app/(authenticated)/components/SideNav.tsx
@@ -22,7 +22,7 @@ const navItems: NavItem[] = [
   },
   {
     title: "動画一覧",
-    href: "/movies",
+    href: "/videos",
     icon: <FileVideo className="h-5 w-5" />,
   },
   {


### PR DESCRIPTION
## 変更内容
サイドバーに動画一覧を追加しました。

## 関連Issue
https://github.com/Singuralitylabs/portal-site/issues/61

## 特記事項
- 動画の機能フォルダを "videos" 想定としたため、変更希望あれば調整させてください  
 調査メモ >> video: ショート動画からオンラインコンテンツまで、movie: 長編動画など
-  mantine のアイコンの中から、FileVideoを選択。他により良いものがあれば[こちら](https://lucide.dev/icons/categories?search=video)から教えてください

