### PR TITLE
📝 設計書の認証機能をSupabase Authに変更

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -91,14 +91,6 @@ Supabaseは、PostgreSQLを基盤としたオープンソースのバックエ�
 
 ```mermaid
 erDiagram
-    auth_users {
-        UUID id PK "Supabase Auth ユーザーID"
-        VARCHAR email "メールアドレス"
-        JSONB user_metadata "ユーザーメタデータ"
-        TIMESTAMP created_at "作成日時"
-        TIMESTAMP updated_at "更新日時"
-    }
-
     users {
         SERIAL id PK "レコードの一意な識別子（連番）"
         UUID auth_id FK "Supabase Auth ユーザーID"
@@ -153,7 +145,6 @@ erDiagram
         TIMESTAMP updated_at "更新日時"
     }
 
-    auth_users ||--|| users : "1:1"
     users ||--o{ documents : "1:N"
     users ||--o{ videos : "1:N"
     categories ||--o{ documents : "1:N"

--- a/docs/database.md
+++ b/docs/database.md
@@ -8,7 +8,7 @@ Supabaseは、PostgreSQLを基盤としたオープンソースのバックエ�
 本プロジェクトでは以下の3種類のデータを管理します。
 
 1. **ユーザー情報**（`users`テーブル）  
-   Googleアカウント認証を活用したユーザー情報を管理します。
+   Supabase Authと連携したユーザー情報を管理します。
 
 2. **ドキュメント情報**（`documents`テーブル）  
    資料やリンクなどのドキュメント情報を管理します。
@@ -26,7 +26,7 @@ Supabaseは、PostgreSQLを基盤としたオープンソースのバックエ�
 | カラム名       | データ型       | 制約                                | 説明                                            |
 | -------------- | -------------- | ----------------------------------- | ----------------------------------------------- |
 | `id`           | `SERIAL`       | PRIMARY KEY                         | レコードの一意な識別子（連番）                  |
-| `clerk_id`     | `VARCHAR(255)` | UNIQUE, NOT NULL                    | Clerkが発行する一意なID                         |
+| `auth_id`      | `UUID`         | UNIQUE, NOT NULL, FK(auth.users.id) | Supabase Authのユーザー ID                      |
 | `email`        | `VARCHAR(255)` | UNIQUE, NOT NULL                    | Googleアカウントのメールアドレス（最大255文字） |
 | `display_name` | `VARCHAR(100)` | NOT NULL                            | Googleアカウントの表示名                        |
 | `role`         | `VARCHAR(50)`  | DEFAULT 'member' NOT NULL           | ユーザーの役割（例: member, admin）             |
@@ -40,60 +40,68 @@ Supabaseは、PostgreSQLを基盤としたオープンソースのバックエ�
 
 ### 2.2. documents テーブル
 
-| カラム名      | データ型       | 制約                                | 説明                               |
-| ------------- | -------------- | ----------------------------------- | ---------------------------------- |
-| `id`          | `SERIAL`       | PRIMARY KEY                         | レコードの一意な識別子（連番）     |
-| `name`        | `VARCHAR(255)` | NOT NULL                            | 資料名                             |
-| `description` | `TEXT`         |                                     | 資料の説明文                       |
-| `category_id` | `INTEGER`      | FOREIGN KEY(categories.id), NOT NULL | 資料の分類       |
-| `url`         | `TEXT`         | NOT NULL                            | 資料へのリンク（Googleドライブ等） |
-| `created_by`  | `INTEGER`      | FOREIGN KEY(users.id), NOT NULL     | 資料を作成したユーザー             |
-| `updated_by`  | `INTEGER`      | FOREIGN KEY(users.id), NOT NULL     | 資料を最後に更新したユーザー       |
-| `assignee`    | `VARCHAR(100)` |                                     | 資料の担当者名                     |
-| `is_deleted`  | `BOOLEAN`      | DEFAULT FALSE, NOT NULL             | 論理削除フラグ                     |
-| `created_at`  | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL | 作成日時                           |
-| `updated_at`  | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL | 更新日時                           |
+| カラム名      | データ型       | 制約                                 | 説明                               |
+| ------------- | -------------- | ------------------------------------ | ---------------------------------- |
+| `id`          | `SERIAL`       | PRIMARY KEY                          | レコードの一意な識別子（連番）     |
+| `name`        | `VARCHAR(255)` | NOT NULL                             | 資料名                             |
+| `description` | `TEXT`         |                                      | 資料の説明文                       |
+| `category_id` | `INTEGER`      | FOREIGN KEY(categories.id), NOT NULL | 資料の分類                         |
+| `url`         | `TEXT`         | NOT NULL                             | 資料へのリンク（Googleドライブ等） |
+| `created_by`  | `INTEGER`      | FOREIGN KEY(users.id), NOT NULL      | 資料を作成したユーザー             |
+| `updated_by`  | `INTEGER`      | FOREIGN KEY(users.id), NOT NULL      | 資料を最後に更新したユーザー       |
+| `assignee`    | `VARCHAR(100)` |                                      | 資料の担当者名                     |
+| `is_deleted`  | `BOOLEAN`      | DEFAULT FALSE, NOT NULL              | 論理削除フラグ                     |
+| `created_at`  | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL  | 作成日時                           |
+| `updated_at`  | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL  | 更新日時                           |
 
 ---
 
 ### 2.3. videos テーブル
 
-| カラム名         | データ型       | 制約                                | 説明                             |
-| ---------------- | -------------- | ----------------------------------- | -------------------------------- |
-| `id`             | `SERIAL`       | PRIMARY KEY                         | レコードの一意な識別子（連番）   |
-| `name`           | `VARCHAR(255)` | NOT NULL                            | 動画名                           |
-| `description`    | `TEXT`         |                                     | 動画の説明文                     |
-| `category_id`    | `INTEGER`      | FOREIGN KEY(categories.id), NOT NULL | 動画の分類       |
-| `url`            | `TEXT`         | NOT NULL                            | 動画へのリンク（Youtube等）      |
-| `thumbnail_path` | `TEXT`         |                                     | サムネイル画像パス               |
-| `thumbnail_time` | `INTEGER`      |                                     | サムネイルのタイミング（秒換算） |
-| `length`         | `INTEGER`      |                                     | 動画の再生時間（秒換算）         |
-| `created_by`     | `INTEGER`      | FOREIGN KEY(users.id), NOT NULL     | 動画を作成したユーザー           |
-| `updated_by`     | `INTEGER`      | FOREIGN KEY(users.id), NOT NULL     | 動画を最後に更新したユーザー     |
-| `assignee`       | `VARCHAR(100)` |                                     | 動画の担当者名（講師など）       |
-| `is_deleted`     | `BOOLEAN`      | DEFAULT FALSE, NOT NULL             | 論理削除フラグ                   |
-| `created_at`     | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL | 作成日時                         |
-| `updated_at`     | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL | 更新日時                         |
+| カラム名         | データ型       | 制約                                 | 説明                             |
+| ---------------- | -------------- | ------------------------------------ | -------------------------------- |
+| `id`             | `SERIAL`       | PRIMARY KEY                          | レコードの一意な識別子（連番）   |
+| `name`           | `VARCHAR(255)` | NOT NULL                             | 動画名                           |
+| `description`    | `TEXT`         |                                      | 動画の説明文                     |
+| `category_id`    | `INTEGER`      | FOREIGN KEY(categories.id), NOT NULL | 動画の分類                       |
+| `url`            | `TEXT`         | NOT NULL                             | 動画へのリンク（Youtube等）      |
+| `thumbnail_path` | `TEXT`         |                                      | サムネイル画像パス               |
+| `thumbnail_time` | `INTEGER`      |                                      | サムネイルのタイミング（秒換算） |
+| `length`         | `INTEGER`      |                                      | 動画の再生時間（秒換算）         |
+| `created_by`     | `INTEGER`      | FOREIGN KEY(users.id), NOT NULL      | 動画を作成したユーザー           |
+| `updated_by`     | `INTEGER`      | FOREIGN KEY(users.id), NOT NULL      | 動画を最後に更新したユーザー     |
+| `assignee`       | `VARCHAR(100)` |                                      | 動画の担当者名（講師など）       |
+| `is_deleted`     | `BOOLEAN`      | DEFAULT FALSE, NOT NULL              | 論理削除フラグ                   |
+| `created_at`     | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL  | 作成日時                         |
+| `updated_at`     | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL  | 更新日時                         |
 
 ### 2.4. categories テーブル
 
-| カラム名        | データ型       | 制約                                | 説明                              |
-| --------------- | -------------- | ----------------------------------- | --------------------------------- |
-| `id`            | `SERIAL`       | PRIMARY KEY                         | レコードの一意な識別子（連番）    |
-| `category_type` | `VARCHAR(50)`  | NOT NULL, `documents` OR `videos`   | カテゴリーの種別 |
-| `name`          | `VARCHAR(100)` | NOT NULL                            | カテゴリー名 （例: 事務局資料）   |
-| `description`   | `TEXT`         |                                     | カテゴリーの説明文                |
-| `is_deleted`    | `BOOLEAN`      | DEFAULT FALSE, NOT NULL             | 論理削除フラグ                    |
-| `created_at`    | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL | 作成日時                          |
-| `updated_at`    | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL | 更新日時                          |
+| カラム名        | データ型       | 制約                                | 説明                            |
+| --------------- | -------------- | ----------------------------------- | ------------------------------- |
+| `id`            | `SERIAL`       | PRIMARY KEY                         | レコードの一意な識別子（連番）  |
+| `category_type` | `VARCHAR(50)`  | NOT NULL, `documents` OR `videos`   | カテゴリーの種別                |
+| `name`          | `VARCHAR(100)` | NOT NULL                            | カテゴリー名 （例: 事務局資料） |
+| `description`   | `TEXT`         |                                     | カテゴリーの説明文              |
+| `is_deleted`    | `BOOLEAN`      | DEFAULT FALSE, NOT NULL             | 論理削除フラグ                  |
+| `created_at`    | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL | 作成日時                        |
+| `updated_at`    | `TIMESTAMP`    | DEFAULT CURRENT_TIMESTAMP, NOT NULL | 更新日時                        |
 
 ## 3. ER図
 
 ```mermaid
 erDiagram
+    auth_users {
+        UUID id PK "Supabase Auth ユーザーID"
+        VARCHAR email "メールアドレス"
+        JSONB user_metadata "ユーザーメタデータ"
+        TIMESTAMP created_at "作成日時"
+        TIMESTAMP updated_at "更新日時"
+    }
+
     users {
         SERIAL id PK "レコードの一意な識別子（連番）"
-        VARCHAR clerk_id "Clerkが発行する一意なID (最大255文字)"
+        UUID auth_id FK "Supabase Auth ユーザーID"
         VARCHAR email "Googleアカウントのメールアドレス (最大255文字)"
         VARCHAR display_name "Googleアカウントの表示名 (最大100文字)"
         VARCHAR role "ユーザーの役割（例: member, admin） (最大50文字)"
@@ -145,6 +153,7 @@ erDiagram
         TIMESTAMP updated_at "更新日時"
     }
 
+    auth_users ||--|| users : "1:1"
     users ||--o{ documents : "1:N"
     users ||--o{ videos : "1:N"
     categories ||--o{ documents : "1:N"
@@ -161,8 +170,8 @@ Supabaseでは、Row Level Security（RLS）を使用してデータアクセス
 
 - `users_can_read_own_data`: ユーザーは自分自身のデータのみ閲覧可能
 
-  - 条件: `clerk_id = get_clerk_user_id() AND is_deleted = FALSE`
-  - 解説: 論理削除されていない自分自身のレコードのみ閲覧可能。
+  - 条件: `auth_id = auth.uid() AND is_deleted = FALSE`
+  - 解説: 論理削除されていない自分自身のレコードのみ閲覧可能。`auth.uid()`はSupabase Authの組み込み関数で、現在認証されているユーザーのUUIDを返す。
 
 - `admins_can_read_all_users`: 管理者は全ユーザーデータを閲覧可能
   - 条件:
@@ -170,7 +179,7 @@ Supabaseでは、Row Level Security（RLS）を使用してデータアクセス
     EXISTS (
         SELECT 1 FROM users
         WHERE
-        clerk_id = get_clerk_user_id()
+        auth_id = auth.uid()
         AND role = 'admin'
         AND status = 'active'
         AND is_deleted = FALSE
@@ -180,16 +189,16 @@ Supabaseでは、Row Level Security（RLS）を使用してデータアクセス
 
 #### 挿入ポリシー（INSERT）
 
-- `webhook_can_insert_users`: Clerk Webhookからの新規ユーザー登録を許可
+- `authenticated_users_can_insert_own_data`: 認証済みユーザーは自分自身のデータを挿入可能
   - 条件: `true`（実質的にサービスロールからの実行のみ許可）
-  - 解説: このポリシーは主にClerkのWebhookからの登録処理用。通常のユーザーからの直接挿入は想定していない。Webhookはサービスロールを使用して実行され、RLSポリシーをバイパスする。
+  - 解説: OAuth認証後のコールバック処理で、ユーザー自身のデータをusersテーブルに登録する際に使用。
 
 #### 更新ポリシー（UPDATE）
 
 - `users_can_update_own_data`: ユーザーは自分自身の情報のみ更新可能
 
-  - 条件1（USING）: `clerk_id = get_clerk_user_id() AND is_deleted = FALSE`
-  - 条件2（WITH CHECK）: `clerk_id = get_clerk_user_id() AND is_deleted = FALSE`
+  - 条件1（USING）: `auth_id = auth.uid() AND is_deleted = FALSE`
+  - 条件2（WITH CHECK）: `auth_id = auth.uid() AND is_deleted = FALSE`
   - 解説: 自分自身のデータのみ更新可能で、かつ論理削除されていない場合に限る。USINGは更新対象の行を選択する条件、WITH CHECKは更新後の値をチェックする条件を指定。ユーザーは自分のプロフィール情報などを変更できる。
 
 - `admins_can_update_all_users`: 管理者はすべてのユーザー情報を更新可能
@@ -198,7 +207,7 @@ Supabaseでは、Row Level Security（RLS）を使用してデータアクセス
     EXISTS (
         SELECT 1 FROM users
         WHERE
-        clerk_id = get_clerk_user_id()
+        auth_id = auth.uid()
         AND role = 'admin'
         AND status = 'active'
         AND is_deleted = FALSE
@@ -210,8 +219,8 @@ Supabaseでは、Row Level Security（RLS）を使用してデータアクセス
 
 - `users_can_delete_own_data`: ユーザーは自分自身の論理削除のみ可能
 
-  - 条件1（USING）: `clerk_id = get_clerk_user_id() AND is_deleted = FALSE`
-  - 条件2（WITH CHECK）: `clerk_id = get_clerk_user_id() AND is_deleted = TRUE`
+  - 条件1（USING）: `auth_id = auth.uid() AND is_deleted = FALSE`
+  - 条件2（WITH CHECK）: `auth_id = auth.uid() AND is_deleted = TRUE`
   - 解説: ユーザーは自分自身のデータのみ論理削除可能。実際には物理削除ではなく、`is_deleted = TRUE`に更新することで論理削除を実現。退会処理に相当する。
 
 - `admins_can_delete_users`: 管理者はユーザーの論理削除が可能
@@ -220,7 +229,7 @@ Supabaseでは、Row Level Security（RLS）を使用してデータアクセス
     EXISTS (
         SELECT 1 FROM users
         WHERE
-        clerk_id = get_clerk_user_id()
+        auth_id = auth.uid()
         AND role = 'admin'
         AND status = 'active'
         AND is_deleted = FALSE
@@ -232,87 +241,37 @@ Supabaseでは、Row Level Security（RLS）を使用してデータアクセス
 
 #### 閲覧ポリシー（SELECT）
 
-- `registered_users_can_read_documents`: 登録済みユーザーは全てのdocumentsを閲覧可能
-  - 条件: `is_registered_user() AND status = 'active' AND is_deleted = FALSE`
-  - 解説: `is_registered_user()`関数を使用して、現在ログインしているユーザーがusersテーブルに正しく登録されており、承認済み (status = 'active') かつ論理削除されていないことを確認する。この条件を満たすユーザーのみが、削除されていない全ての資料（documents）にアクセスできる。つまり、シンラボメンバーとして正規登録されたユーザーだけが資料を閲覧できる仕組み。
+- `registered_users_can_read_documents`: 承認済みユーザーは全てのdocumentsを閲覧可能
+  - 条件: `auth_id = auth.uid()　AND status = 'active' AND is_deleted = FALSE`
+  - 解説: `auth.uid()`を使用して、現在ログインしているユーザーがusersテーブルに正しく登録されており、承認済み (status = 'active') かつ論理削除されていないことを確認する。この条件を満たすユーザーのみが、削除されていない全ての資料（documents）にアクセスできる。つまり、シンラボメンバーとして承認されたユーザーだけが資料を閲覧できる仕組み。
 
 ### 4.3. videos テーブルのRLSポリシー
 
 #### 閲覧ポリシー（SELECT）
 
-- `registered_users_can_read_videos`: 登録済みユーザーは全てのvideosを閲覧可能
-  - 条件: `is_registered_user() AND status = 'active' AND is_deleted = FALSE`
-  - 解説: documentsテーブルと同様に、`is_registered_user()`関数を使用して、ログインユーザーが正規登録されたシンラボメンバーであり、承認済み (status = 'active') かつ論理削除されていないことを確認する。この条件を満たすユーザーのみが、論理削除されていない全ての動画（videos）にアクセスできる。会員以外の一般ユーザーは動画を閲覧できない仕組みになっている。
+- `registered_users_can_read_videos`: 承認済みユーザーは全てのvideosを閲覧可能
+  - 条件: `auth_id = auth.uid()　AND status = 'active' AND is_deleted = FALSE`
+  - 解説: documentsテーブルと同様に、`auth.uid()`を使用して、ログインユーザーが正規登録されたシンラボメンバーであり、承認済み (status = 'active') かつ論理削除されていないことを確認する。この条件を満たすユーザーのみが、論理削除されていない全ての動画（videos）にアクセスできる。未承認ユーザーは動画を閲覧できない仕組みになっている。
 
 ### 4.4. categories テーブルのRLSポリシー
 
 #### 閲覧ポリシー（SELECT）
 
 - `registered_users_can_read_categories`: 登録済みユーザーは全てのcategoriesを閲覧可能
-  - 条件: `is_registered_user() AND status = 'active' AND is_deleted = FALSE`
-  - 解説: documentsテーブルと同様に、`is_registered_user()`関数を使用して、ログインユーザーが正規登録されたシンラボメンバーであり、承認済み (status = 'active') かつ論理削除されていないことを確認する。この条件を満たすユーザーのみが、論理削除されていない全てのカテゴリー（categories）にアクセスできる。会員以外の一般ユーザーは閲覧できない仕組みになっている。
+  - 条件: `auth_id = auth.uid()　AND status = 'active' AND is_deleted = FALSE`
+  - 解説: documentsテーブルと同様に、`auth.uid()`を使用して、ログインユーザーが正規登録されたシンラボメンバーであり、承認済み (status = 'active') かつ論理削除されていないことを確認する。この条件を満たすユーザーのみが、論理削除されていない全てのカテゴリー（categories）にアクセスできる。会員以外の一般ユーザーは閲覧できない仕組みになっている。
 
 ## 5. サポート関数
 
-RLSポリシーで使用される主要な関数は以下の通りです。
+- `auth.uid()`: 現在認証されているユーザーのUUIDを取得
+  - 解説: Supabase Authが提供する組み込み関数で、現在のセッションで認証されているユーザーのUUIDを返す。未認証の場合はNULLを返す。RLSポリシーでユーザー識別に使用される。これが主要な認証識別関数として使用される。
 
-- `set_clerk_user_id(clerk_id TEXT)`: クライアントからClerk IDを設定するための関数
-  - 定義:
-    ```sql
-    CREATE OR REPLACE FUNCTION set_clerk_user_id(clerk_id TEXT)
-    RETURNS VOID AS $
-    BEGIN
-        PERFORM set_config('app.clerk_user_id', clerk_id, false);
-    END;
-    $ LANGUAGE plpgsql SECURITY DEFINER;
-    ```
-  - 解説: アプリケーションからClerk IDをデータベースセッション変数(`app.clerk_user_id`)に設定する関数。認証されたユーザーのIDを設定し、RLSポリシーでの権限チェックに使用される。`SECURITY DEFINER`はこの関数が定義者の権限で実行されることを意味し、権限昇格の仕組みとして機能する。
-- `get_clerk_user_id()`: セッション変数からClerk IDを取得する関数
-  - 定義:
-    ```sql
-    CREATE OR REPLACE FUNCTION get_clerk_user_id()
-    RETURNS TEXT AS $
-    BEGIN
-        RETURN current_setting('app.clerk_user_id', true);
-    EXCEPTION
-        WHEN OTHERS THEN RETURN NULL;
-    END;
-    $ LANGUAGE plpgsql SECURITY DEFINER;
-    ```
-  - 解説: セッション変数に設定されたClerk IDを取得する関数。RLSポリシー内で現在のユーザーを識別するために使用される。`current_setting`の第二引数が`true`の場合、設定が存在しない場合はエラーではなくNULLを返す。例外処理によってエラー発生時も安全にNULLを返すようになっている。
-- `is_registered_user()`: Clerk IDがusersテーブルに存在していることをチェックする関数
+## 6. データアクセス制御の実現
 
-  - 定義:
+これらのRLSポリシーとSupabase Auth統合により、シンラボポータルサイトでは以下のデータアクセス制御を実現しています。
 
-    ```sql
-    CREATE OR REPLACE FUNCTION is_registered_user()
-    RETURNS BOOLEAN AS $
-    DECLARE
-        current_clerk_id TEXT;
-    BEGIN
-        current_clerk_id := get_clerk_user_id();
-
-        IF current_clerk_id IS NULL THEN
-        RETURN FALSE;
-        END IF;
-
-        RETURN EXISTS (
-        SELECT 1 FROM users
-        WHERE
-            clerk_id = current_clerk_id
-        );
-    EXCEPTION
-        WHEN OTHERS THEN RETURN FALSE;
-    END;
-    $ LANGUAGE plpgsql SECURITY DEFINER;
-    ```
-
-  - 解説: 現在のユーザーが正規登録されたメンバーであるかを確認する関数。まず`get_clerk_user_id()`で現在のClerk IDを取得し、そのIDがusersテーブルに存在することをチェックする。これにより未登録ユーザーによるアクセスを防止する。この関数はdocumentsやvideosテーブルのRLSポリシーで使用され、登録メンバーのみがコンテンツにアクセスできるようにしている。
-
-これらの関数とRLSポリシーにより、シンラボポータルサイトでは以下のデータアクセス制御を実現しています。
-
-- **アクセス制限**: 一般ユーザーは自分自身の情報のみ閲覧・更新可能
+- **認証ベースアクセス**: Supabase Authで認証されたユーザーのみアクセス可能
 - **管理者特権**: 管理者は全ユーザー情報を閲覧・更新可能
 - **メンバー限定コンテンツ**: 登録済みユーザーのみが資料・動画コンテンツを閲覧可能
 - **データ保全**: 物理削除は禁止され、論理削除のみ許可（データの整合性保持）
-- **セキュアな認証連携**: ClerkとSupabaseの連携により、セキュアな認証と権限管理を実現
+- **シンプルな権限管理**: Supabase Authとの統合により、複雑な認証連携処理が不要

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1,3 +1,29 @@
 # デザイン
+
 ## lucide-react
+
 https://lucide.dev/icons/
+
+# Clerkからの移行による改善点
+
+## アーキテクチャの簡素化
+
+**移行前（Clerk）:**
+
+- Clerk認証 → Webhook → Supabase同期 → RLSポリシー（`get_clerk_user_id()`）
+
+**移行後（Supabase Auth）:**
+
+- Supabase Auth → 直接RLSポリシー（`auth.uid()`）
+
+## パフォーマンス向上
+
+- **外部API呼び出し削除**: ClerkのAPI呼び出しが不要
+- **Webhook処理削除**: 非同期同期処理のオーバーヘッドが削除
+- **統合データアクセス**: 認証とデータが同一データベース内で処理
+
+## 開発・運用効率
+
+- **管理画面統一**: Supabaseダッシュボードで認証・データ両方を管理
+- **デバッグ簡素化**: 全ての処理がSupabase内で完結
+- **コスト削減**: Clerkの有料プラン不要


### PR DESCRIPTION
## 変更内容

* 設計書におけるポータルサイトへのGoogle認証処理を、ClerkからSupabase Authに変更

## 関連Issue

- [123](https://github.com/Singuralitylabs/portal-site/issues/123)

## 特記事項

* 設計書の記載内容に不備や不明点がないか
* 認証処理のシーケンス図を追加して問題ないか

## 備考

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
