### PR TITLE
usersテーブルのclerk_idをauth_idに変更

### DIFF
--- a/supabase/migrations/01_tables/03_alter_clerk_id_to_auth_id_for_users_table.sql
+++ b/supabase/migrations/01_tables/03_alter_clerk_id_to_auth_id_for_users_table.sql
@@ -1,0 +1,12 @@
+-- usersテーブルのclerk_idカラムをauth_idに変更
+  ALTER TABLE users
+    RENAME COLUMN clerk_id TO auth_id;
+
+  -- auth_idカラムのデータ型をUUIDに変更
+  ALTER TABLE users
+    ALTER COLUMN auth_id TYPE UUID USING auth_id::UUID;
+
+  -- auth_idカラムに外部キー制約を追加
+  ALTER TABLE users
+    ADD CONSTRAINT fk_users_auth_id
+    FOREIGN KEY (auth_id) REFERENCES auth.users(id);


### PR DESCRIPTION
## 変更内容

Google認証をClerkからsupabase Authに移行するため、現行のusersテーブルのカラムにある`clerk_id`を`auth_id`に変更し、型や外部キーも修正

## 関連Issue


- #123 

## 特記事項

auth_idの型や外部キーに問題はないか

## 備考

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
