### PR TITLE
動画で気づいた資料関連のリファクタリング

### DIFF
--- a/app/(authenticated)/documents/components/DocumentCard.tsx
+++ b/app/(authenticated)/documents/components/DocumentCard.tsx
@@ -11,12 +11,12 @@ import { DocumentFormModal } from './DocumentFormModal';
 
 interface DocumentCardProps {
   document: DocumentWithCategoryType;
-  currentUserRole: string;
+  isAdmin: boolean;
   categories: CategoryType[];
   userId: number;
 }
 
-export function DocumentCard({ document, currentUserRole, categories, userId }: DocumentCardProps) {
+export function DocumentCard({ document, isAdmin, categories, userId }: DocumentCardProps) {
   const [deleteModalOpened, setDeleteModalOpened] = useState(false);  // 削除モーダル用
   const [editModalOpened, setEditModalOpened] = useState(false);  // 編集モーダル用
   const router = useRouter();
@@ -31,7 +31,7 @@ export function DocumentCard({ document, currentUserRole, categories, userId }: 
 
   const handleDelete = async (id: number) => {
     try {
-      const result = await deleteDocument(id);
+      const result = await deleteDocument(id, userId);
       setDeleteModalOpened(false);
       if (result?.success) {
         notifications.show({
@@ -57,7 +57,6 @@ export function DocumentCard({ document, currentUserRole, categories, userId }: 
       console.error(e);
     }
   };
-  const isAdmin = currentUserRole === 'admin';
 
   return (
     <Card component="div" shadow="sm" padding="lg" radius="md" w="100%" withBorder>

--- a/app/(authenticated)/documents/components/DocumentFormModal.tsx
+++ b/app/(authenticated)/documents/components/DocumentFormModal.tsx
@@ -15,29 +15,27 @@ interface DocumentFormModalProps {
     initialData?: DocumentUpdateFormType; // 編集時のデータ
 }
 
+function toDocumentFormState(document?: DocumentUpdateFormType) {
+    return {
+        name: document?.name ?? '',
+        category_id: document?.category_id ?? 0,
+        description: document?.description ?? '',
+        url: document?.url ?? '',
+        assignee: document?.assignee ?? '',
+    };
+}
+
 export function DocumentFormModal({ opened, onClose, categories, userId, initialData }: DocumentFormModalProps) {
-    const [form, setForm] = useState({
-        name: initialData?.name ?? '',
-        category_id: initialData?.category_id ?? 0,
-        description: initialData?.description ?? '',
-        url: initialData?.url ?? '',
-        assignee: initialData?.assignee ?? '',
-    });
+    const [form, setForm] = useState(toDocumentFormState(initialData));
     const router = useRouter();
 
     // モーダルが開かれたとき、編集時はinitialDataでformを更新
     useEffect(() => {
-        setForm({
-            name: initialData?.name ?? "",
-            category_id: initialData?.category_id ?? 0,
-            description: initialData?.description ?? "",
-            url: initialData?.url ?? "",
-            assignee: initialData?.assignee ?? "",
-        });
+        setForm(toDocumentFormState(initialData));
     }, [opened, initialData]);
 
     const handleSubmit = async () => {
-        if (!form.name || !form.url || form.category_id === 0 || form.url.trim() === "") {
+        if (!form.name || !form.url?.trim() || form.category_id === 0) {
             notifications.show({
                 title: '入力エラー',
                 message: '資料名とURL及びカテゴリーは必須です',

--- a/app/(authenticated)/documents/components/Template.tsx
+++ b/app/(authenticated)/documents/components/Template.tsx
@@ -60,7 +60,7 @@ export function DocumentsPageTemplate({ documents, categories, currentUserRole, 
                   <Grid.Col span={{ base: 12, md: 6, lg: 4 }} key={document.id + '_grid'}>
                     <DocumentCard
                       document={document}
-                      currentUserRole={currentUserRole}
+                      isAdmin={isAdmin}
                       categories={categories}
                       userId={userId}
                     />

--- a/app/services/api/documents-client.ts
+++ b/app/services/api/documents-client.ts
@@ -4,13 +4,17 @@ import type { DocumentInsertFormType, DocumentUpdateFormType } from "@/app/types
 /**
  * 指定したidの資料を論理削除する
  * @param id 資料のid
+ * @param userId ユーザーID
  * @returns 削除結果
  * - success: 成功した場合はtrue
  * - error: エラーが発生した場合はPostgrestErrorオブジェクト
  */
-export async function deleteDocument(id: number) {
+export async function deleteDocument(id: number, userId: number) {
   const supabase = createClientSupabaseClient();
-  const { error } = await supabase.from("documents").update({ is_deleted: true }).eq("id", id);
+  const { error } = await supabase
+    .from("documents")
+    .update({ is_deleted: true, updated_by: userId })
+    .eq("id", id);
 
   if (error) {
     console.error("Supabase 資料削除エラー:", error.message);


### PR DESCRIPTION
## 変更内容
動画データの制御に付随して、資料側でも同じ対応をしている部分のリファクタリングを別ブランチで作成します

## 関連Issue
- #137 

## 特記事項
- 冗長処理の関数化
- ロールではなくAdminフラグを連携
- 削除時にも更新ユーザーが記録される　etc
## 備考
- あわせて気になる点があれば、ご指摘拝見し反映させていただきます。

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
