### PR TITLE
新規ユーザーのSlack通知機能の追加

### DIFF
--- a/app/api/notifications/slack/route.ts
+++ b/app/api/notifications/slack/route.ts
@@ -8,21 +8,12 @@ interface SlackNotificationPayloadType {
       type: string;
       text: string;
     };
-    fields?: Array<{
-      type: string;
-      text: string;
-    }>;
   }>;
-}
-
-interface NewUserNotificationType {
-  displayName: string;
-  authId: string;
 }
 
 export async function POST(request: NextRequest) {
   try {
-    const userData: NewUserNotificationType = await request.json();
+    const { displayName } = await request.json();
     const webhookUrl = process.env.SLACK_WEBHOOK_URL;
 
     if (!webhookUrl) {
@@ -42,26 +33,9 @@ export async function POST(request: NextRequest) {
         },
         {
           type: "section",
-          fields: [
-            {
-              type: "mrkdwn",
-              text: `*ユーザー名:*\n${userData.displayName}`,
-            },
-            {
-              type: "mrkdwn",
-              text: `*ステータス:*\n承認待ち`,
-            },
-            {
-              type: "mrkdwn",
-              text: `*登録日時:*\n${new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}`,
-            },
-          ],
-        },
-        {
-          type: "section",
           text: {
             type: "mrkdwn",
-            text: "管理者による承認作業をお願いします。\n承認は管理画面から行ってください。",
+            text: `${displayName}さんがポータルサイトに新規登録されました。管理者は承認作業をお願いします。`,
           },
         },
       ],

--- a/app/api/notifications/slack/route.ts
+++ b/app/api/notifications/slack/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+
+interface SlackNotificationPayloadType {
+  text: string;
+  blocks?: Array<{
+    type: string;
+    text?: {
+      type: string;
+      text: string;
+    };
+    fields?: Array<{
+      type: string;
+      text: string;
+    }>;
+  }>;
+}
+
+interface NewUserNotificationType {
+  displayName: string;
+  authId: string;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userData: NewUserNotificationType = await request.json();
+    const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+
+    if (!webhookUrl) {
+      console.warn("SLACK_WEBHOOK_URL環境変数が設定されていないため、Slack通知をスキップします");
+      return NextResponse.json({ success: true, message: "環境変数未設定のためスキップ" });
+    }
+
+    const payload: SlackNotificationPayloadType = {
+      text: "新規ユーザー登録の承認依頼",
+      blocks: [
+        {
+          type: "header",
+          text: {
+            type: "plain_text",
+            text: "新規ユーザー登録の承認依頼",
+          },
+        },
+        {
+          type: "section",
+          fields: [
+            {
+              type: "mrkdwn",
+              text: `*ユーザー名:*\n${userData.displayName}`,
+            },
+            {
+              type: "mrkdwn",
+              text: `*ステータス:*\n承認待ち`,
+            },
+            {
+              type: "mrkdwn",
+              text: `*登録日時:*\n${new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}`,
+            },
+          ],
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "管理者による承認作業をお願いします。\n承認は管理画面から行ってください。",
+          },
+        },
+      ],
+    };
+
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("Slack通知の送信に失敗:", response.status, errorText);
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Slack API エラー: ${response.status} ${errorText}`,
+        },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Slack通知の送信エラー:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "不明なエラー",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/providers/supabase-auth-provider.tsx
+++ b/app/providers/supabase-auth-provider.tsx
@@ -116,7 +116,6 @@ export function SupabaseAuthProvider({
               },
               body: JSON.stringify({
                 displayName: user.user_metadata?.full_name || "",
-                authId: user.id,
               }),
             });
 

--- a/app/providers/supabase-auth-provider.tsx
+++ b/app/providers/supabase-auth-provider.tsx
@@ -97,13 +97,40 @@ export function SupabaseAuthProvider({
       const { userId, error: userError } = await fetchUserIdByAuthId({ authId: user.id });
       // 新規ユーザーの場合、usersテーブルに追加
       if (!userId || userError) {
-        await addNewUser({
+        const { error: newUserError } = await addNewUser({
           authId: user.id,
           email: user.email || "",
           displayName: user.user_metadata?.full_name || "",
           avatarUrl: user.user_metadata?.avatar_url || user.user_metadata?.picture || null,
         });
-        console.log("新規ユーザーをusersテーブルに追加:", user.id);
+
+        if (!newUserError) {
+          console.log("新規ユーザーをusersテーブルに追加:", user.id);
+
+          // 新規ユーザー作成成功後にSlack通知を送信（非同期で実行、エラーでも処理は継続）
+          try {
+            const response = await fetch("/api/notifications/slack", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                displayName: user.user_metadata?.full_name || "",
+                authId: user.id,
+              }),
+            });
+
+            if (!response.ok) {
+              const result = await response.json();
+              console.error(
+                "Slack通知の送信に失敗しましたが、ユーザー作成は完了しました:",
+                result.error
+              );
+            }
+          } catch (notificationError) {
+            console.error("Slack通知の送信に失敗:", notificationError);
+          }
+        }
       }
     } catch (error) {
       console.error("ユーザー情報の同期エラー:", error);


### PR DESCRIPTION
## 変更内容

新規ユーザー登録時に、シンラボSlackの「202-club_チーム開発_通知用」チャンネルに通知する処理を追加しました。

## 関連Issue

- #182 

## 特記事項

* SlackのWebhook URLが必要なため、.env.localに`SLACK_WEBHOOK_URL`を設定する必要あり

## 備考

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
