### PR TITLE
動画・資料カードサイズの修正

### DIFF
--- a/app/(authenticated)/components/SideNav.tsx
+++ b/app/(authenticated)/components/SideNav.tsx
@@ -60,8 +60,8 @@ export function SideNav() {
   return (
     <>
       {/* ハンバーガーメニュー (モバイル用) */}
-      <Button variant="subtle" onClick={() => setOpen(true)} className="sm:hidden">
-        <Menu size={24} className="sm:hidden" />
+      <Button variant="subtle" onClick={() => setOpen(true)} className="sm:hidden mt-4">
+        <Menu size={32} className="sm:hidden" />
       </Button>
 
       {/* モバイル用ハンバーガーメニュー */}

--- a/app/(authenticated)/documents/components/DocumentCard.tsx
+++ b/app/(authenticated)/documents/components/DocumentCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DocumentWithCategoryType } from "@/app/types";
-import { Calendar, EllipsisVertical, FileText, FileType } from "lucide-react";
+import { EllipsisVertical, FileText, FileType } from "lucide-react";
 import { Button, Card, Flex, Text, Menu } from "@mantine/core";
 
 interface DocumentCardProps {
@@ -22,8 +22,15 @@ export function DocumentCard({ document, isContentMgr, onEdit, onDelete }: Docum
   };
 
   return (
-    <Card component="div" shadow="sm" padding="lg" radius="md" w="100%" withBorder>
-      <Card.Section withBorder inheritPadding py="xs">
+    <Card
+      component="div"
+      shadow="sm"
+      padding="0"
+      radius="md"
+      withBorder
+      className="w-full h-[240px] flex flex-col"
+    >
+      <Card.Section withBorder inheritPadding p="xs">
         <Flex gap="0.25rem" justify="space-between" align="center" direction="row">
           <Flex gap="0.25rem" align="center" direction="row">
             <div>{getFileTypeIcon("pdf")}</div>
@@ -46,54 +53,32 @@ export function DocumentCard({ document, isContentMgr, onEdit, onDelete }: Docum
                 </Button>
               </Menu.Target>
               <Menu.Dropdown>
-                <Menu.Item onClick={() => onEdit(document)}>
-                  編集
-                </Menu.Item>
-                <Menu.Item onClick={() => onDelete(document.id)}>
-                  削除
-                </Menu.Item>
+                <Menu.Item onClick={() => onEdit(document)}>編集</Menu.Item>
+                <Menu.Item onClick={() => onDelete(document.id)}>削除</Menu.Item>
               </Menu.Dropdown>
             </Menu>
           )}
         </Flex>
       </Card.Section>
-      <Card.Section>
-        <Text component="div" p="1rem">
+
+      <div className="flex-1 p-4">
+        <Text component="div" lineClamp={4}>
           {document.description}
         </Text>
-        <Flex gap="0.25rem" justify="flex-start" align="center" direction="row" p="0 1rem 1rem">
-          <Calendar style={{ width: "1rem", height: "1rem" }} />
-          <Text component="div" fs="0.875rem" lh="1.25rem">
-            {new Date(document.updated_at)
-              .toLocaleDateString("ja-JP", { year: "numeric", month: "2-digit", day: "2-digit" })
-              .replaceAll("/", "-")}
-          </Text>
-          <Button
-            component="div"
-            radius="md"
-            size="compact-sm"
-            c="rgb(23,23,23)"
-            bg="gray.2"
-            fs="0.875rem"
-            lh="1.25rem"
-            ml="0.5rem"
-          >
-            {document.category?.name}
-          </Button>
-        </Flex>
+      </div>
+
+      <div className="p-4 pt-0">
         <Button
           color="#000"
           component="a"
           href={document.url}
-          w={"100% - 2rem"}
-          m="0 1rem 1rem"
-          display="block"
+          fullWidth
           target="_blank"
           rel="noopener noreferrer"
         >
           資料を開く
         </Button>
-      </Card.Section>
-    </Card >
+      </div>
+    </Card>
   );
 }

--- a/app/(authenticated)/documents/components/DocumentFormModal.tsx
+++ b/app/(authenticated)/documents/components/DocumentFormModal.tsx
@@ -116,6 +116,7 @@ export function DocumentFormModal({
       <Textarea
         label="説明文"
         value={form.description}
+        placeholder="文字数は70文字以内にしてください。"
         onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
         mb="sm"
       />

--- a/app/(authenticated)/documents/components/Template.tsx
+++ b/app/(authenticated)/documents/components/Template.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { DocumentCard } from "./DocumentCard";
-import { Grid, Paper, Button, Group } from "@mantine/core";
+import { Button } from "@mantine/core";
 import { PageTitle } from "@/app/components/PageTitle";
 import { DocumentFormModal } from "./DocumentFormModal";
 import { DocumentWithCategoryType, CategoryType, DocumentUpdateFormType } from "@/app/types";
@@ -47,49 +47,47 @@ export function DocumentsPageTemplate({
   };
 
   return (
-    <Paper m="0 2rem">
-      <Group justify="space-between" align="center" mb="md">
-        <PageTitle>資料一覧</PageTitle>
-        {isContentMgr && (
-          <Button onClick={() => setFormModalOpened(true)} color="blue">
+    <div className="p-4 overflow-x-hidden">
+      <PageTitle>資料一覧</PageTitle>
+      {isContentMgr && (
+        <div className="mt-4 flex justify-end">
+          <Button onClick={() => setFormModalOpened(true)} color="blue" size="xs" variant="outline">
             新規登録
           </Button>
-        )}
-      </Group>
-
-      <Paper mb="md" p="md">
-        <div className="flex flex-wrap items-center">
-          {existingCategories.map(category => (
-            <div key={category.id}>
-              <a href={`#category-${category.id}`} className="text-blue-600 mr-4">
-                {category.name}
-              </a>
-            </div>
-          ))}
         </div>
-      </Paper>
+      )}
 
-      <Paper>
+      <div className="mb-4 py-4 flex flex-wrap items-center">
+        {existingCategories.map(category => (
+          <div key={category.id}>
+            <a href={`#category-${category.id}`} className="text-blue-600 mr-4">
+              {category.name}
+            </a>
+          </div>
+        ))}
+      </div>
+
+      <div>
         {existingCategories.map(category => (
           <div key={category.id}>
             <h2 id={`category-${category.id}`}>{category.name}</h2>
-            <Grid>
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 lg:gap-8 mb-8">
               {documents
                 .filter(document => document.category?.name === category.name)
                 .map(document => (
-                  <Grid.Col span={{ base: 12, md: 6, lg: 4 }} key={document.id + "_grid"}>
+                  <div key={document.id} className="w-full">
                     <DocumentCard
                       document={document}
                       isContentMgr={isContentMgr}
                       onEdit={handleEditDocument}
                       onDelete={handleDeleteDocument}
                     />
-                  </Grid.Col>
+                  </div>
                 ))}
-            </Grid>
+            </div>
           </div>
         ))}
-      </Paper>
+      </div>
 
       <div className="text-left mt-8 mb-4">
         <a href="#" className="text-blue-600">
@@ -111,6 +109,6 @@ export function DocumentsPageTemplate({
         userId={userId}
         documentId={deletingDocumentId}
       />
-    </Paper>
+    </div>
   );
 }

--- a/app/(authenticated)/documents/components/Template.tsx
+++ b/app/(authenticated)/documents/components/Template.tsx
@@ -51,7 +51,7 @@ export function DocumentsPageTemplate({
       <PageTitle>資料一覧</PageTitle>
       {isContentMgr && (
         <div className="mt-4 flex justify-end">
-          <Button onClick={() => setFormModalOpened(true)} color="blue" size="xs" variant="outline">
+          <Button onClick={() => setFormModalOpened(true)} size="xs" variant="outline">
             新規登録
           </Button>
         </div>
@@ -69,7 +69,7 @@ export function DocumentsPageTemplate({
 
       <div>
         {existingCategories.map(category => (
-          <div key={category.id}>
+          <div key={category.id} className="mb-12">
             <h2 id={`category-${category.id}`}>{category.name}</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 lg:gap-8 mb-8">
               {documents

--- a/app/(authenticated)/videos/[id]/components/Template.tsx
+++ b/app/(authenticated)/videos/[id]/components/Template.tsx
@@ -6,6 +6,7 @@ import { PageTitle } from "@/app/components/PageTitle";
 import { getYouTubeVideoId } from "@/app/(authenticated)/videos/utils";
 import Link from "next/link";
 import YouTube from "react-youtube";
+import { Calendar } from "lucide-react";
 
 interface VideoDetailPageProps {
   video: VideoWithCategoryType;
@@ -40,7 +41,6 @@ export function VideoDetailPageTemplate({ video }: VideoDetailPageProps) {
               >
                 <Grid justify="space-between" align="center" columns={12} w="100%">
                   <Grid.Col span={6}>
-                    {/* 動画のカテゴリー */}
                     <Button
                       component="div"
                       radius="md"
@@ -53,25 +53,35 @@ export function VideoDetailPageTemplate({ video }: VideoDetailPageProps) {
                     </Button>
                   </Grid.Col>
                   <Grid.Col span={6}>
-                    {/* 担当者情報 */}
                     {video.assignee && (
-                      // 担当者情報ありの場合は表示する
                       <Flex w="100%" justify="flex-end">
                         <Text>担当：{video.assignee}</Text>
                       </Flex>
                     )}
                   </Grid.Col>
                 </Grid>
-                {/* 動画の長さ */}
-                {video.length && (
-                  // ビデオの長さ情報がある場合は表示する
-                  <Flex w="100%" justify="flex-end">
+                <Flex w="100%" justify="space-between" align="center">
+                  <Flex align="center" gap="0.25rem">
+                    <Calendar style={{ width: "1rem", height: "1rem" }} />
+                    <Text component="div" fs="0.875rem" lh="1.25rem">
+                      {new Date(video.updated_at)
+                        .toLocaleDateString("ja-JP", {
+                          year: "numeric",
+                          month: "2-digit",
+                          day: "2-digit",
+                        })
+                        .replaceAll("/", "-")}
+                    </Text>
+                  </Flex>
+                  {video.length ? (
                     <Text>
                       ビデオの長さ {Math.floor(Number(video.length) / 60)}:
                       {(Number(video.length) % 60).toString().padStart(2, "0")}
                     </Text>
-                  </Flex>
-                )}
+                  ) : (
+                    ""
+                  )}
+                </Flex>
               </Flex>
             </div>
             <Divider color="#999" m="0 1rem" />

--- a/app/(authenticated)/videos/components/Template.tsx
+++ b/app/(authenticated)/videos/components/Template.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { VideoCard } from "./VideoCard";
-import { Grid, Paper, Button, Group } from "@mantine/core";
+import { Button } from "@mantine/core";
 import { PageTitle } from "@/app/components/PageTitle";
 import { VideoFormModal } from "./VideoFormModal";
 import { VideoWithCategoryType, CategoryType, VideoUpdateFormType } from "@/app/types";
@@ -45,17 +45,17 @@ export function VideosPageTemplate({
   };
 
   return (
-    <Paper m="0 2rem">
-      <Group justify="space-between" align="center" mb="md">
-        <PageTitle>動画一覧</PageTitle>
-        {isContentMgr && (
-          <Button onClick={() => setFormModalOpened(true)} color="blue">
+    <div className="p-4 overflow-x-hidden">
+      <PageTitle>動画一覧</PageTitle>
+      {isContentMgr && (
+        <div className="mt-4 flex justify-end">
+          <Button onClick={() => setFormModalOpened(true)} size="xs" variant="outline">
             新規登録
           </Button>
-        )}
-      </Group>
+        </div>
+      )}
 
-      <Paper mb="md" p="md">
+      <div className="mb-4 py-4">
         <div className="flex flex-wrap items-center">
           {existingCategories.map(category => (
             <div key={category.id}>
@@ -65,29 +65,29 @@ export function VideosPageTemplate({
             </div>
           ))}
         </div>
-      </Paper>
+      </div>
 
-      <Paper>
+      <div>
         {existingCategories.map(category => (
-          <div key={category.id}>
+          <div key={category.id} className="mb-12">
             <h2 id={`category-${category.id}`}>{category.name}</h2>
-            <Grid>
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 mb-8">
               {videos
                 .filter(video => video.category?.name === category.name)
                 .map(video => (
-                  <Grid.Col span={{ base: 12, md: 6, lg: 4 }} key={video.id + "_grid"}>
+                  <div key={video.id} className="w-full">
                     <VideoCard
                       video={video}
                       isContentMgr={isContentMgr}
                       onEdit={handleEditDocument}
                       onDelete={handleDeleteDocument}
                     />
-                  </Grid.Col>
+                  </div>
                 ))}
-            </Grid>
+            </div>
           </div>
         ))}
-      </Paper>
+      </div>
 
       <div className="text-left mt-8 mb-4">
         <a href="#" className="text-blue-600">
@@ -109,6 +109,6 @@ export function VideosPageTemplate({
         userId={userId}
         videoId={deletingVideoId}
       />
-    </Paper>
+    </div>
   );
 }

--- a/app/(authenticated)/videos/components/Template.tsx
+++ b/app/(authenticated)/videos/components/Template.tsx
@@ -55,16 +55,14 @@ export function VideosPageTemplate({
         </div>
       )}
 
-      <div className="mb-4 py-4">
-        <div className="flex flex-wrap items-center">
-          {existingCategories.map(category => (
-            <div key={category.id}>
-              <a href={`#category-${category.id}`} className="text-blue-600 mr-4">
-                {category.name}
-              </a>
-            </div>
-          ))}
-        </div>
+      <div className="mb-4 py-4 flex flex-wrap items-center">
+        {existingCategories.map(category => (
+          <div key={category.id}>
+            <a href={`#category-${category.id}`} className="text-blue-600 mr-4">
+              {category.name}
+            </a>
+          </div>
+        ))}
       </div>
 
       <div>

--- a/app/(authenticated)/videos/components/VideoCard.tsx
+++ b/app/(authenticated)/videos/components/VideoCard.tsx
@@ -33,10 +33,8 @@ export function VideoCard({ video, isContentMgr, onEdit, onDelete }: VideoCardPr
       shadow="sm"
       padding="0"
       radius="md"
-      w="100%"
-      h="320px"
       withBorder
-      className="hover:shadow-lg transition-shadow"
+      className="hover:shadow-lg transition-shadow w-full h-[300px]"
     >
       <Card.Section component="a" href={`/videos/${video.id}`}>
         {isContentMgr && (

--- a/app/(authenticated)/videos/components/VideoCard.tsx
+++ b/app/(authenticated)/videos/components/VideoCard.tsx
@@ -4,8 +4,7 @@ import { VideoWithCategoryType } from "@/app/types";
 import Image from "next/image";
 import { getYouTubeVideoId } from "@/app/(authenticated)/videos/utils";
 import { EllipsisVertical } from "lucide-react";
-import { Calendar } from "lucide-react";
-import { Card, Button, Flex, Menu, Text } from "@mantine/core";
+import { Card, Button, Menu, Text } from "@mantine/core";
 
 interface VideoCardProps {
   video: VideoWithCategoryType;
@@ -88,33 +87,13 @@ export function VideoCard({ video, isContentMgr, onEdit, onDelete }: VideoCardPr
           <Image src={thumbnailUrl} alt={video.name} fill style={{ objectFit: "cover" }} />
         </div>
         <div className="p-4">
-          <Text fw={700} size="lg" mb="xs">
+          <Text fw={700} size="lg" mb="xs" lineClamp={1}>
             {video.name}
           </Text>
           <Text component="div" lineClamp={2} c="dimmed" mb="md">
             {video.description}
           </Text>
         </div>
-      </Card.Section>
-      <Card.Section className="p-4">
-        <Flex gap="0.25rem" justify="space-between" align="center" direction="row">
-          <Calendar style={{ width: "1rem", height: "1rem" }} />
-          <Text component="div" fs="0.875rem" lh="1.25rem">
-            {new Date(video.updated_at)
-              .toLocaleDateString("ja-JP", { year: "numeric", month: "2-digit", day: "2-digit" })
-              .replaceAll("/", "-")}
-          </Text>
-          <Button
-            component="div"
-            radius="md"
-            size="compact-sm"
-            c="rgb(23,23,23)"
-            bg="gray.2"
-            fs="0.875rem"
-          >
-            {video.category?.name}
-          </Button>
-        </Flex>
       </Card.Section>
     </Card>
   );

--- a/app/(authenticated)/videos/components/VideoCard.tsx
+++ b/app/(authenticated)/videos/components/VideoCard.tsx
@@ -35,6 +35,7 @@ export function VideoCard({ video, isContentMgr, onEdit, onDelete }: VideoCardPr
       padding="0"
       radius="md"
       w="100%"
+      h="320px"
       withBorder
       className="hover:shadow-lg transition-shadow"
     >
@@ -81,7 +82,8 @@ export function VideoCard({ video, isContentMgr, onEdit, onDelete }: VideoCardPr
                 </Menu.Item>
               </Menu.Dropdown>
             </Menu>
-          </div>)}
+          </div>
+        )}
         <div className="aspect-video mx-auto" style={{ position: "relative" }}>
           <Image src={thumbnailUrl} alt={video.name} fill style={{ objectFit: "cover" }} />
         </div>


### PR DESCRIPTION
## 変更内容

動画一覧・資料一覧ページの、カードサイズ及びレイアウトを調整しました。

* カードサイズを固定値に変更
* 画面サイズによってカードが画面からはみ出すことがあったため、グリッド表示をtailwindCSSを使った実装に変更
* 「新規登録」ボタンの位置を、ページタイトルと並列配置からタイトルの右下に移動
* 「新規登録」ボタンの色を、outlineに変更（色が目立ちすぎて個人的に気になったため）
* 動画・資料カードから、「カテゴリー」タグと作成日を削除（カテゴリータグは分類表示と重複するため、作成日は不要な情報と判断）
* 動画詳細ページに「カテゴリー」タグと作成日を追加

## 関連Issue

- #189 

## 特記事項

* 動画一覧・資料一覧ページのレイアウトやカードサイズに問題はないか

## 備考

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
