### PR TITLE
カードのアスペクト比の固定化

### DIFF
--- a/app/(authenticated)/documents/components/DocumentCard.tsx
+++ b/app/(authenticated)/documents/components/DocumentCard.tsx
@@ -28,7 +28,7 @@ export function DocumentCard({ document, isContentMgr, onEdit, onDelete }: Docum
       padding="0"
       radius="md"
       withBorder
-      className="w-full h-[240px] flex flex-col"
+      className="w-full aspect-[4/3] flex flex-col"
     >
       <Card.Section withBorder inheritPadding p="xs">
         <Flex gap="0.25rem" justify="space-between" align="center" direction="row">
@@ -61,8 +61,8 @@ export function DocumentCard({ document, isContentMgr, onEdit, onDelete }: Docum
         </Flex>
       </Card.Section>
 
-      <div className="flex-1 p-4">
-        <Text component="div" lineClamp={4}>
+      <div className="flex-1 p-4 overflow-hidden">
+        <Text component="div" lineClamp={4} className="overflow-hidden">
           {document.description}
         </Text>
       </div>

--- a/app/(authenticated)/documents/components/Template.tsx
+++ b/app/(authenticated)/documents/components/Template.tsx
@@ -71,7 +71,7 @@ export function DocumentsPageTemplate({
         {existingCategories.map(category => (
           <div key={category.id} className="mb-12">
             <h2 id={`category-${category.id}`}>{category.name}</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 lg:gap-8 mb-8">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 lg:gap-8 mb-8">
               {documents
                 .filter(document => document.category?.name === category.name)
                 .map(document => (

--- a/app/(authenticated)/members/components/Template.tsx
+++ b/app/(authenticated)/members/components/Template.tsx
@@ -1,4 +1,4 @@
-import { Container, SimpleGrid, Text } from "@mantine/core";
+import { Text } from "@mantine/core";
 import { MemberCard } from "./MemberCard";
 import { PageTitle } from "@/app/components/PageTitle";
 import { MemberType } from "@/app/types";
@@ -12,7 +12,7 @@ export function MembersPageTemplate({ members }: MembersPageTemplateProps) {
   const sortedMembers = members.sort((a, b) => a.display_name.localeCompare(b.display_name, "ja"));
 
   return (
-    <Container size="xl" py="md">
+    <div className="p-4 overflow-x-hidden">
       <PageTitle>シンラボ会員一覧</PageTitle>
 
       <Text my={16} size="lg" c="gray.9">
@@ -23,14 +23,14 @@ export function MembersPageTemplate({ members }: MembersPageTemplateProps) {
       <div>
         {members.length > 0 && (
           <>
-            <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="xl" mt="lg">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 lg:gap-8 mb-8">
               {sortedMembers.map(member => (
                 <MemberCard key={member.id} member={member} />
               ))}
-            </SimpleGrid>
+            </div>
           </>
         )}
       </div>
-    </Container>
+    </div>
   );
 }

--- a/app/(authenticated)/videos/components/Template.tsx
+++ b/app/(authenticated)/videos/components/Template.tsx
@@ -69,7 +69,7 @@ export function VideosPageTemplate({
         {existingCategories.map(category => (
           <div key={category.id} className="mb-12">
             <h2 id={`category-${category.id}`}>{category.name}</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 mb-8">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 lg:gap-8 mb-8">
               {videos
                 .filter(video => video.category?.name === category.name)
                 .map(video => (

--- a/app/(authenticated)/videos/components/VideoCard.tsx
+++ b/app/(authenticated)/videos/components/VideoCard.tsx
@@ -34,7 +34,7 @@ export function VideoCard({ video, isContentMgr, onEdit, onDelete }: VideoCardPr
       padding="0"
       radius="md"
       withBorder
-      className="hover:shadow-lg transition-shadow w-full h-[300px]"
+      className="hover:shadow-lg transition-shadow w-full aspect-square"
     >
       <Card.Section component="a" href={`/videos/${video.id}`}>
         {isContentMgr && (


### PR DESCRIPTION
## 変更内容

前にマージされた動画カードの縦横比固定の実装では、ブラウザの画面サイズによってサムネイルに隠れてカードタイトルが見えなくなるというバグ（下記画像）が発生したため、カードの縦幅ではなく、アスペクト比を固定する方針に変更

<img width="1630" height="911" alt="スクリーンショット 2025-09-14 12 31 05" src="https://github.com/user-attachments/assets/f8887984-50f4-4a17-8c6d-7954c9cadb77" />

また、画面サイズによっては縦3列では余計にカードが大きくなるため、縦4列まで許容する実装に変更（資料カード・メンバーカードも同様）

## 関連Issue

- #189 

## 特記事項

* 本実装・レイアウトで問題はないか

## 備考

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
