### PR TITLE
データ取得処理の並列化

### DIFF
--- a/app/(authenticated)/documents/page.tsx
+++ b/app/(authenticated)/documents/page.tsx
@@ -17,7 +17,14 @@ export default async function DocumentsPage() {
     );
   }
 
-  const { data: documents, error: documentError } = await fetchDocuments();
+  // 資料データ・カテゴリーデータ・ユーザー情報を並列取得して権限を確認
+  const [documentsResult, categoriesResult, userResult] = await Promise.all([
+    fetchDocuments(),
+    fetchCategoriesByType("documents"),
+    fetchUserInfoByAuthId({ authId: authId }),
+  ]);
+
+  const { data: documents, error: documentError } = documentsResult;
   if (documentError || !documents) {
     console.error("資料データの取得に失敗:", documentError);
     return (
@@ -27,7 +34,7 @@ export default async function DocumentsPage() {
     );
   }
 
-  const { data: categories, error: categoryError } = await fetchCategoriesByType("documents");
+  const { data: categories, error: categoryError } = categoriesResult;
   if (categoryError || !categories) {
     console.error("カテゴリーデータの取得に失敗:", categoryError);
     return (
@@ -37,7 +44,7 @@ export default async function DocumentsPage() {
     );
   }
 
-  const { id: userId, role, error: roleError } = await fetchUserInfoByAuthId({ authId: authId });
+  const { id: userId, role, error: roleError } = userResult;
   if (roleError || !role || !userId) {
     console.error("ユーザー情報の取得に失敗:", roleError);
     return (

--- a/app/(authenticated)/videos/page.tsx
+++ b/app/(authenticated)/videos/page.tsx
@@ -17,7 +17,14 @@ export default async function VideosPage() {
     );
   }
 
-  const { data: videos, error: videoError } = await fetchVideos();
+  // 動画データ・カテゴリーデータ・ユーザー情報を並列取得して権限を確認
+  const [videosResult, categoriesResult, userResult] = await Promise.all([
+    fetchVideos(),
+    fetchCategoriesByType("videos"),
+    fetchUserInfoByAuthId({ authId: authId }),
+  ]);
+
+  const { data: videos, error: videoError } = videosResult;
   if (videoError || !videos) {
     console.error("動画データの取得に失敗:", videoError);
     return (
@@ -27,7 +34,7 @@ export default async function VideosPage() {
     );
   }
 
-  const { data: categories, error: categoryError } = await fetchCategoriesByType("videos");
+  const { data: categories, error: categoryError } = categoriesResult;
   if (categoryError || !categories) {
     console.error("カテゴリーデータの取得に失敗:", categoryError);
     return (
@@ -37,7 +44,7 @@ export default async function VideosPage() {
     );
   }
 
-  const { id: userId, role, error: roleError } = await fetchUserInfoByAuthId({ authId: authId });
+  const { id: userId, role, error: roleError } = userResult;
   if (roleError || !role || !userId) {
     console.error("ユーザー情報の取得に失敗:", roleError);
     return (


### PR DESCRIPTION
## 変更内容

`Promise.all()`コマンドを使って、動画一覧・資料一覧ページにおける、supabaseからの下記データ取得処理を並列化する

* 動画または資料データ
* カテゴリーデータ
* ユーザーデータ

## 関連Issue

- #198 

## 特記事項

* 正常に動画一覧ページ、資料一覧ページが表示されるか

## 備考

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
