### PR TITLE
動画・資料・会員一覧ページの、カードブロックの横幅を縮めて調整

### DIFF
--- a/app/(authenticated)/documents/components/Template.tsx
+++ b/app/(authenticated)/documents/components/Template.tsx
@@ -55,7 +55,7 @@ export function DocumentsPageTemplate({
             <h2 id={`category-${category.id}`} className="scroll-mt-40">
               {category.name}
             </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 lg:gap-6 mb-8 px-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 mb-8 px-4">
               {documents
                 .filter(document => document.category?.name === category.name)
                 .map(document => (

--- a/app/(authenticated)/members/components/Template.tsx
+++ b/app/(authenticated)/members/components/Template.tsx
@@ -18,7 +18,7 @@ export function MembersPageTemplate({ members }: MembersPageTemplateProps) {
       <div>
         {members.length > 0 && (
           <>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 lg:gap-8 mb-8">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 mb-8 px-4">
               {sortedMembers.map(member => (
                 <MemberCard key={member.id} member={member} />
               ))}

--- a/app/(authenticated)/videos/components/Template.tsx
+++ b/app/(authenticated)/videos/components/Template.tsx
@@ -46,8 +46,10 @@ export function VideosPageTemplate({
       <div>
         {existingCategories.map(category => (
           <div key={category.id} className="mb-12">
-            <h2 id={`category-${category.id}`} className="scroll-mt-40">{category.name}</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 lg:gap-8 mb-8">
+            <h2 id={`category-${category.id}`} className="scroll-mt-40">
+              {category.name}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 mb-8 px-4">
               {videos
                 .filter(video => video.category?.name === category.name)
                 .map(video => (


### PR DESCRIPTION
## 概要

<!-- 変更の背景・理由と、変更の概要を記載してください -->

- 資料一覧ページの左右端がギリギリまで広がっていたので、カード間隔を狭め、左右余白を内側に修正した

### 関連Issue

<!-- 関連するIssue番号を記載してください -->

- #234 

## 技術的変更点

<!-- レビュワーに変更の流れが分かるように、どの処理をどう変更したか、どう動くのか、などを記載してください -->

- documents下のTemplate.tsxの、<div>タグ内を一部変更。具体的には→<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6 lg:gap-6 mb-8 px-4">

### レビュー特記事項

<!-- レビュワーに重点的に確認してもらいたい観点や、レビュワーに伝えたい実装意図（本当はこうしようと思ったけど悩みがあってこうした、など）があれば記載してください -->

- まだ、動画一覧ページや会員一覧ページは修正できていませんが、Githubのプルリクエストの練習として、先にリクエストさせていただきました。

### TODO事項

<!-- 修正量が多くなるのでPRを分けたい・Issueの範囲外で見つけたバグなど、今回あえて修正を保留した箇所があれば記載してください（別Issueで対応する予定の場合は番号も） -->

- 後日、動画一覧ページと会員一覧ページも行います。

## 動作確認内容

<!-- 動作確認した内容（環境、ケース）を記載してください。UI変更の場合は、必要に応じて該当箇所のスクリーンショットをドラッグ&ドロップで添付してください -->

-
<img width="1250" height="491" alt="image" src="https://github.com/user-attachments/assets/77f71298-29ab-4f93-8b58-8ed990092ad8" />


## その他

<!-- 他のPRとのマージ順番の制約や、急ぎ対応が必要などの事情があれば記載してください -->

-

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
