### PR TITLE
[Refactor] 「新規登録」の「説明文」欄を５行に拡張(動画、資料、アプリ)

### DIFF
--- a/app/(authenticated)/applications/components/ApplicationFormModal.tsx
+++ b/app/(authenticated)/applications/components/ApplicationFormModal.tsx
@@ -168,6 +168,7 @@ export function ApplicationFormModal({
         value={form.description}
         placeholder="文字数は70文字以内にしてください。"
         onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+        rows={5}
         mb="sm"
       />
       <TextInput

--- a/app/(authenticated)/documents/components/DocumentFormModal.tsx
+++ b/app/(authenticated)/documents/components/DocumentFormModal.tsx
@@ -147,6 +147,7 @@ export function DocumentFormModal({
         value={form.description}
         placeholder="文字数は70文字以内にしてください。"
         onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+        rows={5}
         mb="sm"
       />
       <TextInput

--- a/app/(authenticated)/videos/components/VideoFormModal.tsx
+++ b/app/(authenticated)/videos/components/VideoFormModal.tsx
@@ -151,6 +151,7 @@ export function VideoFormModal({
         value={form.description}
         placeholder="文字数は70文字以内にしてください。"
         onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+        rows={5}
         mb="sm"
       />
       <TextInput


### PR DESCRIPTION
## 概要

<!-- 変更の背景・理由と、変更の概要を記載してください -->

-動画、資料、アプリ各コーナーの「新規登録」モーダル「説明文」欄が狭かったので、５行に拡張

### 関連Issue

<!-- 関連するIssue番号を記載してください -->

- #281 

## 技術的変更点

<!-- レビュワーに変更の流れが分かるように、どの処理をどう変更したか、どう動くのか、などを記載してください -->

- ApplicationFormModal.tsx、DocumentFormModal.tsx、VideoFormModal.tsx、各Textareaを微修正