### PR TITLE
[Bug] tests配下のJest型解決エラーを修正

### DIFF
--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}


### PR DESCRIPTION
## 概要

- Issue #361 の対応として、tests 配下で VS Code が Jest 型を解決できない問題を解消するため、専用 tsconfig を追加

### 関連Issue

- #361

## 技術的変更点

- `tests/tsconfig.json` を新規追加
- `../tsconfig.json` を継承しつつ `compilerOptions.types` に `jest`, `node` を明示
- `include` に `./**/*.ts`, `./**/*.tsx` を指定し tests 配下を VS Code TypeScript Language Service が適切に解決できるよう調整

### レビュー特記事項

- 変更は tests 用 tsconfig の追加のみで、アプリ本体コードへの影響はありません

### TODO事項

- なし

## ユニットテスト

- [x] テストの追加・修正は不要
- [ ] テストを追加・修正した

## 動作確認内容

- `npm run lint`: 成功（既存警告3件）
- `npm run type-check`: 失敗（既存の playwright-local 配下の型解決エラー）
- `npm run build`: 実行結果は本PRコメント参照

## その他

- なし
