### PR TITLE
本番環境リリース自動化ワークフローを実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,12 @@ SUPABASE_PROJECT_ID=your-project-id
 # ----------------------------------------------------------------------
 # Google Calendar（カレンダー連携）
 # ----------------------------------------------------------------------
-# 取得対象のカレンダー ID をカンマ区切りで指定する
-GOOGLE_CALENDAR_IDS=calendar1@group.calendar.google.com,calendar2@group.calendar.google.com,ja.japanese#holiday@group.v.calendar.google.com
+# 取得対象のカレンダーを「alias:calendarId」ペアのカンマ区切りで指定する
+#   - alias: app/constants/calendar.ts の CALENDAR_COLORS に定義されたキー
+#           （singularity-mtg / singularity-event / holiday / test-calendar）
+#   - calendarId: Google Calendar の ID。`#` は %23 に URL エンコードする
+#                 （実装で decodeURIComponent されるため）
+GOOGLE_CALENDAR_IDS=singularity-mtg:your-mtg-calendar-id@group.calendar.google.com,singularity-event:your-event-calendar-id@group.calendar.google.com,holiday:ja.japanese%23holiday@group.v.calendar.google.com
 
 # Google サービスアカウントキー（JSON 文字列）
 # 本番環境では環境変数として設定、ローカル開発では google-service-account.json を配置することでも代替可能

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,40 @@
+# Singularity Lab Portal - 環境変数サンプル
+#
+# 使い方:
+#   1. このファイルを `.env.local` にコピーする
+#        cp .env.example .env.local
+#   2. 各値を実環境のものに差し替える（実際の値は docs/setup.md の案内に従って取得）
+#
+# 注意:
+#   - 本ファイルは Git 管理されているため、実値は絶対に書き込まない
+#   - 新規の環境変数を追加した際は本ファイルにも必ず反映する
+#     （リリース PR で「新規環境変数の検出」が機能する前提）
+
+# ----------------------------------------------------------------------
+# Supabase（認証・データベース）
+# ----------------------------------------------------------------------
+# Supabase プロジェクトの URL（Project Settings → API → Project URL）
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
+
+# Supabase 匿名キー（Project Settings → API → Project API keys → anon public）
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+
+# Supabase Project ID（`npm run db:types` で型生成する際に使用）
+# Project Settings → General → Reference ID
+SUPABASE_PROJECT_ID=your-project-id
+
+# ----------------------------------------------------------------------
+# Google Calendar（カレンダー連携）
+# ----------------------------------------------------------------------
+# 取得対象のカレンダー ID をカンマ区切りで指定する
+GOOGLE_CALENDAR_IDS=calendar1@group.calendar.google.com,calendar2@group.calendar.google.com,ja.japanese#holiday@group.v.calendar.google.com
+
+# Google サービスアカウントキー（JSON 文字列）
+# 本番環境では環境変数として設定、ローカル開発では google-service-account.json を配置することでも代替可能
+GOOGLE_SERVICE_ACCOUNT_KEY={"type":"service_account","project_id":"...","private_key":"...","client_email":"..."}
+
+# ----------------------------------------------------------------------
+# Slack（通知）
+# ----------------------------------------------------------------------
+# 申請通知などを送信する Slack の Incoming Webhook URL
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/your-workspace-id/your-channel-id/your-token

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,141 @@
+name: Create Release
+
+# release ブランチへの PR マージ後、承認ゲートを経て Git タグと GitHub Release を作成する
+# 設計: docs/ci-cd-design.md 4.2 (ガード条件・同時実行制御)
+on:
+  pull_request:
+    branches:
+      - release
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "リリースバージョン番号（X.Y.Z 形式 / 例: 1.2.3）"
+        required: true
+        type: string
+
+# タグ push と GitHub Release 作成のため contents 書き込み権限が必要
+permissions:
+  contents: write
+
+# 同一ワークフローの同時実行を抑止。実行中のものはキャンセルせず後続をキュー待ちさせる
+concurrency:
+  group: create-release
+  cancel-in-progress: false
+
+jobs:
+  # 各種ガード条件のチェック。すべて通過した場合のみ承認ゲート → release ジョブへ進む
+  validate:
+    name: ガード条件チェック
+    runs-on: ubuntu-latest
+    # マージ済みチェック: pull_request トリガーではマージされた場合のみ実行
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      # PR タイトル or 手動入力からバージョン文字列を抽出する
+      - name: バージョン抽出（PR タイトル or 手動入力）
+        id: extract
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          MANUAL_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$MANUAL_VERSION"
+          else
+            # PR タイトルチェック: 「リリース」で始まる PR のみ対象
+            if ! echo "$PR_TITLE" | grep -Eq '^リリース[[:space:]　]'; then
+              echo "::error::PR タイトルが「リリース」で始まりません: $PR_TITLE"
+              exit 1
+            fi
+            # 例: 「リリース 1.2.3」「リリース v1.2.3」→ 1.2.3
+            VERSION=$(echo "$PR_TITLE" | sed -E 's/^リリース[[:space:]　]+v?//' | tr -d '[:space:]　')
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "抽出されたバージョン: $VERSION"
+
+      # バージョン形式チェック: X.Y.Z の形式でなければエラー終了
+      - name: バージョン形式チェック
+        env:
+          VERSION: ${{ steps.extract.outputs.version }}
+        run: |
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::バージョン番号は X.Y.Z 形式である必要があります（抽出値: $VERSION）"
+            exit 1
+          fi
+
+      # タグ重複チェックのため release ブランチをチェックアウト（タグ情報も取得）
+      - name: Checkout release branch with tags
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+
+      # タグ重複チェック: 同名タグが既に存在する場合はエラー終了
+      - name: タグ重複チェック
+        env:
+          VERSION: ${{ steps.extract.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+            echo "::error::タグ \`v${VERSION}\` は既に存在します。バージョン番号を変更してください。"
+            exit 1
+          fi
+          echo "タグ \`v${VERSION}\` は未使用です。続行します。"
+
+  # 承認ゲート付きのリリースジョブ。Environment の Required reviewers で承認待ちになる
+  release:
+    name: タグ作成と GitHub Release 公開
+    runs-on: ubuntu-latest
+    needs: validate
+    # GitHub Environments 側で Required reviewers を設定することで承認ゲートとして機能する
+    environment:
+      name: production-release
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+          # 後続のタグ push に GITHUB_TOKEN を使うため、認証情報を保持
+          persist-credentials: true
+
+      - name: Git ユーザー情報設定
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Git タグ作成と push
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          git tag -a "v${VERSION}" -m "リリース v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: GitHub Release を公開
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "v${VERSION}" \
+            --target release \
+            --title "v${VERSION}" \
+            --generate-notes
+
+      - name: 成功サマリーを出力
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          {
+            echo "## ✅ リリース v${VERSION} を公開しました"
+            echo ""
+            echo "- タグ: \`v${VERSION}\`"
+            echo "- 対象ブランチ: \`release\`"
+            echo "- Release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${VERSION}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -33,6 +33,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     outputs:
       version: ${{ steps.extract.outputs.version }}
+      target_sha: ${{ steps.target.outputs.sha }}
     steps:
       # PR タイトル or 手動入力からバージョン文字列を抽出する
       - name: バージョン抽出（PR タイトル or 手動入力）
@@ -74,6 +75,30 @@ jobs:
           ref: release
           fetch-depth: 0
 
+      # リリース対象コミットの SHA を確定する。
+      # 承認ゲートでの待機中に release ブランチが進んでも、ここで固定した SHA に対してタグを付与することで、
+      # 「意図しないコミットにタグが付く」事故を防ぐ。
+      - name: 対象コミット SHA を確定
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # 手動起動時は現時点の release HEAD を対象とする
+            SHA=$(git rev-parse HEAD)
+          else
+            # PR マージ時は確定済みのマージコミット SHA を使用（承認待ち中の release 進行に影響されない）
+            SHA="$MERGE_SHA"
+          fi
+          if [ -z "$SHA" ]; then
+            echo "::error::対象コミット SHA を決定できませんでした"
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "対象コミット: $SHA"
+
       # タグ重複チェック: 同名タグが既に存在する場合はエラー終了
       - name: タグ重複チェック
         env:
@@ -96,10 +121,11 @@ jobs:
     environment:
       name: production-release
     steps:
-      - name: Checkout release branch
+      # validate ジョブで確定した SHA をチェックアウト（release ブランチ HEAD ではなく固定 SHA）
+      - name: Checkout target commit
         uses: actions/checkout@v4
         with:
-          ref: release
+          ref: ${{ needs.validate.outputs.target_sha }}
           fetch-depth: 0
           # 後続のタグ push に GITHUB_TOKEN を使うため、認証情報を保持
           persist-credentials: true
@@ -121,21 +147,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.validate.outputs.version }}
+          TARGET_SHA: ${{ needs.validate.outputs.target_sha }}
         run: |
           set -euo pipefail
+          # --target に SHA を指定し、リリース対象を確定済みコミットに固定する
           gh release create "v${VERSION}" \
-            --target release \
+            --target "${TARGET_SHA}" \
             --title "v${VERSION}" \
             --generate-notes
 
       - name: 成功サマリーを出力
         env:
           VERSION: ${{ needs.validate.outputs.version }}
+          TARGET_SHA: ${{ needs.validate.outputs.target_sha }}
         run: |
           {
             echo "## ✅ リリース v${VERSION} を公開しました"
             echo ""
             echo "- タグ: \`v${VERSION}\`"
-            echo "- 対象ブランチ: \`release\`"
+            echo "- 対象コミット: \`${TARGET_SHA}\`"
             echo "- Release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/v${VERSION}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,8 +16,10 @@ on:
         type: string
 
 # タグ push と GitHub Release 作成のため contents 書き込み権限が必要
+# また、リリース PR 本文からサマリーを抽出するため pull-requests への読み取り権限も必要
 permissions:
   contents: write
+  pull-requests: read
 
 # 同一ワークフローの同時実行を抑止。実行中のものはキャンセルせず後続をキュー待ちさせる
 concurrency:
@@ -34,6 +36,7 @@ jobs:
     outputs:
       version: ${{ steps.extract.outputs.version }}
       target_sha: ${{ steps.target.outputs.sha }}
+      summary: ${{ steps.summary.outputs.body }}
     steps:
       # PR タイトル or 手動入力からバージョン文字列を抽出する
       - name: バージョン抽出（PR タイトル or 手動入力）
@@ -99,6 +102,61 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "対象コミット: $SHA"
 
+      # リリース PR 本文から「リリースサマリー」セクションを抽出する。
+      # release-pr.yml が <!-- release-summary-start --> ~ <!-- release-summary-end --> で
+      # 囲んで PR 本文に挿入しているため、その間の本文部分を切り出して GitHub Release ノートに反映する。
+      # 抽出失敗（マーカー欠落・PR 特定不可）は致命エラーではなく、自動生成ノートのみで Release を作成する。
+      - name: リリースサマリーを PR 本文から抽出
+        id: summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          # 対象 PR 番号の特定
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # 手動起動時: target_sha をマージコミットに持つ closed PR を逆引き
+            PR_NUMBER=$(gh pr list --base release --state merged --limit 20 \
+              --json number,mergeCommit \
+              --jq ".[] | select(.mergeCommit.oid == \"${TARGET_SHA}\") | .number" \
+              | head -n1 || true)
+          fi
+
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "::warning::対象 PR を特定できませんでした。自動生成ノートのみで Release を作成します。"
+            # 出力は空文字（後段でフォールバック処理）
+            {
+              echo "body<<RELEASE_SUMMARY_EOF"
+              echo "RELEASE_SUMMARY_EOF"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_BODY=$(gh pr view "$PR_NUMBER" --json body --jq .body)
+
+          # マーカー間の本文を awk で抽出（マーカー行自体は除外）
+          EXTRACTED=$(printf '%s\n' "$PR_BODY" | awk '
+            /<!-- release-summary-start -->/ { capture=1; next }
+            /<!-- release-summary-end -->/   { capture=0 }
+            capture { print }
+          ')
+
+          # 全空白（改行・タブ含む）を除去して実質的に空かどうかを判定する
+          if [ -z "$(printf '%s' "$EXTRACTED" | tr -d '[:space:]')" ]; then
+            echo "::warning::PR #${PR_NUMBER} の本文にリリースサマリーマーカーが見つかりませんでした。"
+          else
+            echo "PR #${PR_NUMBER} からリリースサマリーを抽出しました（${#EXTRACTED} 文字）。"
+          fi
+
+          {
+            echo "body<<RELEASE_SUMMARY_EOF"
+            echo "$EXTRACTED"
+            echo "RELEASE_SUMMARY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       # タグ重複チェック: 同名タグが既に存在する場合はエラー終了
       - name: タグ重複チェック
         env:
@@ -148,13 +206,38 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.validate.outputs.version }}
           TARGET_SHA: ${{ needs.validate.outputs.target_sha }}
+          SUMMARY: ${{ needs.validate.outputs.summary }}
         run: |
           set -euo pipefail
+
+          # 自動生成ノート（commit/PR ベース）を API 経由で取得
+          AUTO_NOTES=$(gh api \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="v${VERSION}" \
+            -f target_commitish="${TARGET_SHA}" \
+            --jq .body)
+
+          # 抽出サマリーがあれば冒頭に配置、その下に自動生成ノートを連結
+          NOTES_FILE=$(mktemp)
+          # 全空白（改行・タブ含む）を除去して実質的に内容があるかを判定する
+          if [ -n "$(printf '%s' "$SUMMARY" | tr -d '[:space:]')" ]; then
+            {
+              printf '%s\n\n' "$SUMMARY"
+              echo "---"
+              echo ""
+              echo "$AUTO_NOTES"
+            } > "$NOTES_FILE"
+          else
+            echo "$AUTO_NOTES" > "$NOTES_FILE"
+          fi
+
           # --target に SHA を指定し、リリース対象を確定済みコミットに固定する
           gh release create "v${VERSION}" \
             --target "${TARGET_SHA}" \
             --title "v${VERSION}" \
-            --generate-notes
+            --notes-file "$NOTES_FILE"
 
       - name: 成功サマリーを出力
         env:

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -1,0 +1,85 @@
+name: Fork Sync
+
+# release ブランチへの PR マージ後、フォークリポジトリの release ブランチを同期する
+# 本ワークフローの失敗はリリース全体をブロックしない（create-release.yml とは独立に動作する）
+on:
+  pull_request:
+    branches:
+      - release
+    types:
+      - closed
+  workflow_dispatch:
+
+# 本体リポジトリへの書き込みは不要。フォーク側への push は FORK_SYNC_TOKEN を使用する
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: フォークリポジトリ同期
+    runs-on: ubuntu-latest
+    # pull_request トリガー時はマージされた場合のみ実行（クローズのみは対象外）
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    steps:
+      # 同期対象設定（Variable）の確認
+      - name: 設定値の検証
+        env:
+          FORK_REPO: ${{ vars.FORK_REPO }}
+          FORK_SYNC_TOKEN: ${{ secrets.FORK_SYNC_TOKEN }}
+        run: |
+          MISSING=()
+          if [ -z "$FORK_REPO" ]; then
+            MISSING+=("FORK_REPO（Variable: owner/repo 形式の同期先フォーク）")
+          fi
+          if [ -z "$FORK_SYNC_TOKEN" ]; then
+            MISSING+=("FORK_SYNC_TOKEN（Secret: フォーク側 contents:write 権限を持つトークン）")
+          fi
+
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo "::error::必須パラメータが未設定です。"
+            for m in "${MISSING[@]}"; do
+              echo "::error:: - $m"
+            done
+            echo "::error::[対応方法] Settings > Secrets and variables > Actions で上記を登録してください。"
+            exit 1
+          fi
+
+      # release ブランチの全履歴を取得（タグや過去コミットを含めて push するため）
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+
+      # フォークリポジトリへ release ブランチを push
+      - name: フォークリポジトリへ release ブランチを push
+        env:
+          FORK_REPO: ${{ vars.FORK_REPO }}
+          FORK_SYNC_TOKEN: ${{ secrets.FORK_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+          # トークンをコマンドラインや echo に出さないよう URL は git remote 経由で渡す
+          git remote add fork "https://x-access-token:${FORK_SYNC_TOKEN}@github.com/${FORK_REPO}.git"
+          git push fork release:release
+
+      - name: 成功サマリーを出力
+        run: |
+          {
+            echo "## ✅ フォーク同期完了"
+            echo ""
+            echo "- 同期先: \`${{ vars.FORK_REPO }}\`"
+            echo "- 同期元ブランチ: \`release\`"
+            echo "- 同期コミット: \`$(git rev-parse HEAD)\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # 失敗時の警告サマリー。create-release.yml とは独立して動作するためリリース全体は止まらない
+      - name: 失敗時の警告サマリーを出力
+        if: ${{ failure() }}
+        run: |
+          {
+            echo "## ⚠️ フォーク同期失敗"
+            echo ""
+            echo "フォークリポジトリの同期に失敗しましたが、リリース全体はブロックされません。"
+            echo "ログを確認の上、必要に応じてこのワークフローを **Re-run** するか、"
+            echo "**workflow_dispatch** から手動で再実行してください。"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -44,7 +44,9 @@ jobs:
             exit 1
           fi
 
-      # release ブランチの全履歴を取得（タグや過去コミットを含めて push するため）
+      # release ブランチの全履歴を取得（fork 側との fast-forward 関係を git push で検証するため。
+      # 浅い clone だと fast-forward 判定ができず push が拒否される場合があるため fetch-depth: 0 とする。
+      # 本ステップは release ブランチのみを対象とし、タグは push しない）
       - name: Checkout release branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,195 @@
+name: Release PR
+
+# main から release への「リリース PR」を作成するワークフロー
+# 手動起動時にバージョン番号を受け取り、品質チェックとリリース時の事前作業
+# （マイグレーション・新規環境変数）を自動で検出し、PR 本文に記載する
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "リリースバージョン番号（X.Y.Z 形式 / 例: 1.2.3）"
+        required: true
+        type: string
+
+# GITHUB_TOKEN の権限を必要最小限に制限する
+permissions:
+  contents: read
+  pull-requests: write
+
+# 連打による二重 PR 作成を防止する。実行中のジョブはキャンセルせず後発をキュー待ちにする
+concurrency:
+  group: release-pr
+  cancel-in-progress: false
+
+jobs:
+  # 入力バリデーション。後段ジョブの無駄な実行を防ぐため最初に実行する
+  validate-input:
+    name: 入力値の検証
+    runs-on: ubuntu-latest
+    steps:
+      - name: バージョン形式チェック
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::バージョン番号は X.Y.Z 形式で指定してください（指定値: $VERSION）"
+            exit 1
+          fi
+
+  # main ブランチに対する品質ゲート。失敗時は PR を作成しない
+  quality-checks:
+    name: 品質チェック (${{ matrix.task }})
+    runs-on: ubuntu-latest
+    needs: validate-input
+    strategy:
+      fail-fast: false
+      matrix:
+        # 通常 PR 向け CI と同じチェックを fail-fast で実施する
+        # （build / type-check / lint / test に加え、console.log・debugger 検知の lint:logs）
+        task: [build, type-check, lint, test, lint:logs]
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ${{ matrix.task }}
+        run: |
+          case "${{ matrix.task }}" in
+            build)      npm run build ;;
+            type-check) npm run type-check ;;
+            lint)       npm run lint ;;
+            test)       npm test ;;
+            lint:logs)  npm run lint:logs ;;
+          esac
+
+  # 事前作業の検出とリリース PR 作成
+  create-pr:
+    name: リリース PR 作成
+    runs-on: ubuntu-latest
+    needs: quality-checks
+    steps:
+      # release / main 両ブランチの履歴を遡るため全履歴を取得
+      - name: Checkout repository (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # release と main の双方を最新化（git fetch だけでは origin/release が無い環境への保険）
+      - name: Fetch release and main branches
+        run: |
+          git fetch origin main:refs/remotes/origin/main
+          git fetch origin release:refs/remotes/origin/release
+
+      # release..main で追加・変更されたマイグレーションファイルを抽出
+      - name: マイグレーション差分を検出
+        id: migrations
+        run: |
+          set -euo pipefail
+          MIGRATIONS=$(git diff --name-only --diff-filter=AM \
+            origin/release..origin/main -- 'supabase/migrations/' \
+            | grep -E '\.sql$' || true)
+
+          {
+            echo "list<<MIGRATIONS_EOF"
+            if [ -z "$MIGRATIONS" ]; then
+              echo "- なし"
+            else
+              echo "$MIGRATIONS" | while IFS= read -r f; do
+                [ -n "$f" ] && echo "- \`$f\`"
+              done
+            fi
+            echo "MIGRATIONS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # .env.example の差分から新規追加された環境変数キーを抽出
+      - name: 新規環境変数を検出
+        id: env-vars
+        run: |
+          set -euo pipefail
+          # 各ブランチの .env.example を取得（存在しない場合は空ファイル扱い）
+          git show origin/release:.env.example > /tmp/env.release 2>/dev/null || : > /tmp/env.release
+          git show origin/main:.env.example    > /tmp/env.main    2>/dev/null || : > /tmp/env.main
+
+          # KEY=VALUE 形式の行から KEY のみを抽出（コメント・空行は除外）
+          extract_keys() {
+            grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$1" | sed -E 's/=.*$//' | sort -u
+          }
+
+          extract_keys /tmp/env.release > /tmp/keys.release || : > /tmp/keys.release
+          extract_keys /tmp/env.main    > /tmp/keys.main    || : > /tmp/keys.main
+
+          # main にあって release に無いキー = 新規追加された環境変数
+          NEW_KEYS=$(comm -13 /tmp/keys.release /tmp/keys.main || true)
+
+          {
+            echo "list<<ENVVARS_EOF"
+            if [ -z "$NEW_KEYS" ]; then
+              echo "- なし"
+            else
+              echo "$NEW_KEYS" | while IFS= read -r k; do
+                [ -n "$k" ] && echo "- \`$k\`"
+              done
+            fi
+            echo "ENVVARS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # 既存の main→release オープン PR がある場合は二重作成しない
+      - name: 既存リリース PR の存在確認
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NUMBER=$(gh pr list --base release --head main --state open \
+            --json number --jq '.[0].number // empty')
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: 既存 PR があれば中断
+        if: ${{ steps.existing.outputs.number != '' }}
+        run: |
+          echo "::error::既存のリリース PR #${{ steps.existing.outputs.number }} が open 状態です。先にこれをマージ／クローズしてください。"
+          exit 1
+
+      - name: リリース PR を作成
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          MIGRATIONS_LIST: ${{ steps.migrations.outputs.list }}
+          ENV_VARS_LIST: ${{ steps.env-vars.outputs.list }}
+        run: |
+          BODY=$(cat <<EOF
+          ## リリース v${VERSION}
+
+          このPRは \`main\` ブランチを \`release\` ブランチへマージするためのリリース PR です。
+          マージ後に \`create-release.yml\` が起動し、承認後に Git タグと GitHub Release が作成されます。
+
+          ### 事前作業の検出結果
+
+          **マイグレーションファイル（release..main で追加・変更）:**
+          ${MIGRATIONS_LIST}
+
+          **新規環境変数（.env.example で追加）:**
+          ${ENV_VARS_LIST}
+
+          ### マージ前チェックリスト
+
+          - [ ] 上記マイグレーションを本番 Supabase に適用済み
+          - [ ] 上記環境変数を本番環境（Vercel 等）に登録済み
+          - [ ] 差分内容を確認済み
+          EOF
+          )
+
+          gh pr create \
+            --base release \
+            --head main \
+            --title "リリース ${VERSION}" \
+            --body "$BODY"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-input
     strategy:
+      # fail-fast: false → 1 つのチェックが失敗しても他のチェックは継続実行する
+      # （build / type-check / lint / test / lint:logs のすべてを並列実行して、リリース前に全ての問題を一度に把握できるようにするため）
       fail-fast: false
       matrix:
-        # 通常 PR 向け CI と同じチェックを fail-fast で実施する
-        # （build / type-check / lint / test に加え、console.log・debugger 検知の lint:logs）
         task: [build, type-check, lint, test, lint:logs]
     steps:
       - name: Checkout main branch
@@ -63,13 +63,20 @@ jobs:
         run: npm ci
 
       - name: Run ${{ matrix.task }}
+        env:
+          TASK: ${{ matrix.task }}
         run: |
-          case "${{ matrix.task }}" in
+          case "$TASK" in
             build)      npm run build ;;
             type-check) npm run type-check ;;
             lint)       npm run lint ;;
             test)       npm test ;;
             lint:logs)  npm run lint:logs ;;
+            *)
+              # matrix.task に対応しない値が来た場合は silent pass にせず明示的に失敗させる
+              echo "::error::未対応のタスクです: $TASK（case 分岐の更新漏れの可能性あり）"
+              exit 1
+              ;;
           esac
 
   # 事前作業の検出とリリース PR 作成

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,6 +10,10 @@ on:
         description: "リリースバージョン番号（X.Y.Z 形式 / 例: 1.2.3）"
         required: true
         type: string
+      summary:
+        description: "リリースサマリー（任意 / PR 本文の冒頭に挿入される）"
+        required: false
+        type: string
 
 # GITHUB_TOKEN の権限を必要最小限に制限する
 permissions:
@@ -170,14 +174,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
+          SUMMARY: ${{ inputs.summary }}
           MIGRATIONS_LIST: ${{ steps.migrations.outputs.list }}
           ENV_VARS_LIST: ${{ steps.env-vars.outputs.list }}
         run: |
+          # summary 入力が空ならセクション全体を省略する（任意入力のため）
+          # NOTE: $(...) は末尾改行を削るため、見出しとの間の空行は heredoc 側で確保する
+          if [ -n "${SUMMARY// /}" ]; then
+            SUMMARY_SECTION=$(printf '### リリースサマリー\n\n%s' "$SUMMARY")
+          else
+            SUMMARY_SECTION=""
+          fi
+
           BODY=$(cat <<EOF
           ## リリース v${VERSION}
 
           このPRは \`main\` ブランチを \`release\` ブランチへマージするためのリリース PR です。
           マージ後に \`create-release.yml\` が起動し、承認後に Git タグと GitHub Release が作成されます。
+
+          ${SUMMARY_SECTION}
 
           ### 事前作業の検出結果
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -180,8 +180,12 @@ jobs:
         run: |
           # summary 入力が空ならセクション全体を省略する（任意入力のため）
           # NOTE: $(...) は末尾改行を削るため、見出しとの間の空行は heredoc 側で確保する
-          if [ -n "${SUMMARY// /}" ]; then
-            SUMMARY_SECTION=$(printf '### リリースサマリー\n\n%s' "$SUMMARY")
+          # NOTE: HTML コメントマーカーは create-release.yml が PR 本文から本文（カテゴリ別の箇条書き）
+          # のみを抽出して Release ノートに転記するために使用する。マーカーで囲むのは本文だけにし、
+          # 「### リリースサマリー」見出しは PR 表示用にマーカー外へ配置する。
+          # 全空白（改行・タブ含む）を除去して実質的に内容があるかを判定する
+          if [ -n "$(printf '%s' "$SUMMARY" | tr -d '[:space:]')" ]; then
+            SUMMARY_SECTION=$(printf '### リリースサマリー\n\n<!-- release-summary-start -->\n%s\n<!-- release-summary-end -->' "$SUMMARY")
           else
             SUMMARY_SECTION=""
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+# .env.example はコミット対象（リリース時の新規環境変数検出と新規メンバーのセットアップに使用）
+!.env.example
 
 # vercel
 .vercel

--- a/docs/ci-cd-design.md
+++ b/docs/ci-cd-design.md
@@ -9,7 +9,8 @@
 3. [共通の権限設計](#3-共通の権限設計)
    - [3.1 ワークフローが持つ権限の制限](#31-ワークフローが持つ権限の制限)
    - [3.2 外部サービスのトークン管理](#32-外部サービスのトークン管理)
-   - [3.3 トークンの一覧](#33-トークンの一覧)
+   - [3.3 トークン・設定値の一覧](#33-トークン設定値の一覧)
+   - [3.4 GitHub Environments](#34-github-environments)
 4. [リリース自動化](#4-リリース自動化)
    - [4.1 ワークフロー一覧](#41-ワークフロー一覧)
    - [4.2 ガード条件と同時実行制御](#42-ガード条件と同時実行制御)
@@ -68,7 +69,7 @@ GitHub 以外のサービス（例: フォークリポジトリ、Supabase）を
 - **有効期限を設定する**: トークンが漏洩していた場合でも、期限切れ後は使用できなくなる
 - **必要な権限だけを付与する**: そのワークフローが必要とする最小限の権限のみを付与し、漏洩時の影響範囲を限定する
 
-### 3.3 トークンの一覧
+### 3.3 トークン・設定値の一覧
 
 **GITHUB_TOKEN:**
 
@@ -88,6 +89,31 @@ GitHub 以外のサービス（例: フォークリポジトリ、Supabase）を
 | --- | --- | --- | --- |
 | `FORK_SYNC_TOKEN` | フォーク同期用トークン | [`fork-sync.yml`](../.github/workflows/fork-sync.yml) | 対象リポジトリをフォークのみに限定し、権限はコードの読み書きのみに制限する |
 | `SUPABASE_ACCESS_TOKEN` | Supabase 接続用トークン | [`db-types.yml`](../.github/workflows/db-types.yml) | |
+
+**Variables:**
+
+機密ではないがワークフローから参照する設定値は GitHub の **Variables** に保存する。登録場所: GitHub リポジトリの **Settings → Secrets and variables → Actions → Variables**
+
+| 名前 | 内容 | 使用ワークフロー | 備考 |
+| --- | --- | --- | --- |
+| `SUPABASE_PROJECT_ID` | 型生成対象の Supabase Project ID | [`db-types.yml`](../.github/workflows/db-types.yml) | |
+| `FORK_REPO` | フォーク同期先リポジトリ（`owner/repo` 形式） | [`fork-sync.yml`](../.github/workflows/fork-sync.yml) | 同期先を切り替える際はこの値だけを変更すればよい |
+
+### 3.4 GitHub Environments
+
+承認ゲート付きのワークフローでは、GitHub の **Environments** 機能を利用する。Environment は事前にリポジトリ側で作成し、保護ルール（Required reviewers 等）を設定する必要がある。
+
+**Required reviewers が未設定の場合、承認ゲートは事実上機能せずジョブが自動で進行する**ため、本番運用を開始する前に必ず設定する。
+
+| 名前 | 用途 | 使用ワークフロー | 必須の保護ルール |
+| --- | --- | --- | --- |
+| `production-release` | タグ作成・GitHub Release 公開前の承認ゲート | [`create-release.yml`](../.github/workflows/create-release.yml) | Required reviewers にリリース承認権限者を登録 |
+
+設定手順:
+
+1. リポジトリの **Settings → Environments → New environment** で `production-release` を作成する
+2. **Deployment protection rules → Required reviewers** にチェックを入れ、リリース承認権限を持つメンバー／チームを追加する
+3. 必要に応じて **Deployment branches and tags** を「Selected branches」にし、`release` ブランチからの実行のみを許可する
 
 ## 4. リリース自動化
 
@@ -136,5 +162,17 @@ concurrency:
 | [`release-pr.yml`](../.github/workflows/release-pr.yml) | PR が作成されない。リリースプロセスは開始されない | 手動での再実行が可能 |
 | [`fork-sync.yml`](../.github/workflows/fork-sync.yml) | フォークリポジトリが同期されない。本番デプロイには影響しない | リリース全体をブロックしない。ジョブサマリーに警告を出力 |
 | [`create-release.yml`](../.github/workflows/create-release.yml) | タグ・Release が作成されない | 手動での再実行が可能。タグ重複チェックにより二重作成を防止 |
+
+#### `create-release.yml` 部分失敗時のリカバリ
+
+[`create-release.yml`](../.github/workflows/create-release.yml) は「タグの push」と「GitHub Release の作成」を順次実行する。前段だけ成功して後段で失敗した場合、ワークフローを単純に再実行するとタグ重複チェックで停止するため、後段のみ手動で補完する必要がある。
+
+| 失敗パターン | 状態 | リカバリ手順 |
+| --- | --- | --- |
+| タグ push 前に失敗 | タグも Release も無い | バージョン番号を確認のうえ、`create-release.yml` を再実行する |
+| タグ push 成功 / Release 作成失敗 | タグのみ存在 | ワークフロー再実行は不可（タグ重複で停止）。**`gh release create vX.Y.Z --target release --title vX.Y.Z --generate-notes` を手動で実行**して Release のみ補完する |
+| Release 作成成功 / 後続失敗（理論上のみ） | タグも Release もある | 後続ステップが追加された場合のみ該当。当該ステップだけを手動で補完する |
+
+タグそのものを誤って作ってしまった場合は、`git push --delete origin vX.Y.Z` でリモートタグを削除してから再実行する。**ローカルタグの削除（`git tag -d`）も併せて行わないと、ローカルから誤って再 push されるおそれがある**点に注意する。
 
 具体的な対応手順は [GitHub Wiki: 本番環境リリース手順](https://github.com/Singuralitylabs/portal-site/wiki/%E6%9C%AC%E7%95%AA%E7%92%B0%E5%A2%83%E3%83%AA%E3%83%AA%E3%83%BC%E3%82%B9%E6%89%8B%E9%A0%86) のトラブルシューティングを参照すること。

--- a/docs/ci-cd-design.md
+++ b/docs/ci-cd-design.md
@@ -113,7 +113,8 @@ GitHub 以外のサービス（例: フォークリポジトリ、Supabase）を
 
 1. リポジトリの **Settings → Environments → New environment** で `production-release` を作成する
 2. **Deployment protection rules → Required reviewers** にチェックを入れ、リリース承認権限を持つメンバー／チームを追加する
-3. 必要に応じて **Deployment branches and tags** を「Selected branches」にし、`release` ブランチからの実行のみを許可する
+
+> **注意**: **Deployment branches and tags** を `release` のみに制限すると、`create-release.yml` を発火させる `pull_request` イベント（`github.ref` が `refs/pull/<n>/merge` になる）や、main ブランチからの `workflow_dispatch` 起動が Environment 制限ではじかれて承認段階に到達できない。本ワークフローでは Required reviewers のみで承認ゲートとし、branch 制限は **設定しない**（"No deployment branch policy" のまま）こと。
 
 ## 4. リリース自動化
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -103,7 +103,7 @@ npm install
    | `NEXT_PUBLIC_SUPABASE_URL` | Supabase プロジェクトのエンドポイント URL。ブラウザ／サーバー双方から Supabase の認証・データベース API へ接続する際に使用する | Supabase Dashboard → Project Settings → API → Project URL |
    | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase の匿名 API キー。クライアント側から Supabase に接続する際の認証に使用される（実権限は RLS で制御される） | Supabase Dashboard → Project Settings → API → anon public |
    | `SUPABASE_PROJECT_ID` | Supabase プロジェクトの一意 ID。`npm run db:types` でデータベース型定義を自動生成する際に使用する（ローカル開発でのみ必要） | Supabase Dashboard → Project Settings → General → Reference ID |
-   | `GOOGLE_CALENDAR_IDS` | 取得対象の Google Calendar の ID 一覧（カンマ区切り）。カレンダー連携機能で予定を取得するために使用する | Google Calendar の各カレンダー設定画面（カンマ区切り） |
+   | `GOOGLE_CALENDAR_IDS` | 取得対象の Google Calendar の `alias:calendarId` ペアをカンマ区切りで指定する。`alias` は `app/constants/calendar.ts` の `CALENDAR_COLORS` で定義されたキー（例: `singularity-mtg` / `singularity-event` / `holiday` / `test-calendar`）。`calendarId` に `#` を含む場合は `%23` に URL エンコードする必要がある（実装で `decodeURIComponent` されるため）。例: `holiday:ja.japanese%23holiday@group.v.calendar.google.com` | Google Calendar の各カレンダー設定画面で取得した ID を、対応する alias と組み合わせる |
    | `GOOGLE_SERVICE_ACCOUNT_KEY` | Google API を呼び出すためのサービスアカウント鍵（JSON 文字列）。カレンダー API への認証に使用する | Google Cloud Console で発行した JSON 鍵の中身（1 行に整形） |
    | `SLACK_WEBHOOK_URL` | Slack に通知を送るための Incoming Webhook URL。申請・承認イベント等の通知送信先として使用する | Slack の Incoming Webhook 設定画面 |
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -88,26 +88,24 @@ npm install
 
 ### 2.3 環境変数の設定
 
-1. `.env.local`ファイルをプロジェクトルートに作成する
+1. プロジェクトルートの `.env.example` をコピーして `.env.local` を作成する
 
    ```bash
-   touch .env.local
+   cp .env.example .env.local
    ```
 
-2. 以下の環境変数を設定する **（各値は参画時に個別共有）**。
+   `.env.example` には本プロジェクトで使用する環境変数のキーがすべて記載されている。新しい環境変数を追加する際は `.env.example` も併せて更新すること（リリース PR の「新規環境変数の検出」が機能する前提となっている）。
 
-   ```bash
-   # Supabase関連（認証・データベース）
-   NEXT_PUBLIC_SUPABASE_URL=https://************.supabase.co
-   NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ*********************************
-   SUPABASE_PROJECT_ID=************
+2. 作成した `.env.local` の各値を実際のものに差し替える **（各値は参画時に個別共有）**。
 
-   # 問い合わせ用メールアドレス
-   NEXT_PUBLIC_ADMIN_EMAIL=info@future-tech-association.org
-
-   # Slack通知先Webhook URL
-   SLACK_WEBHOOK_URL=https://hooks.slack.com/services/***************
-   ```
+   | 変数 | 説明 | 取得元 |
+   | --- | --- | --- |
+   | `NEXT_PUBLIC_SUPABASE_URL` | Supabase プロジェクトのエンドポイント URL。ブラウザ／サーバー双方から Supabase の認証・データベース API へ接続する際に使用する | Supabase Dashboard → Project Settings → API → Project URL |
+   | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase の匿名 API キー。クライアント側から Supabase に接続する際の認証に使用される（実権限は RLS で制御される） | Supabase Dashboard → Project Settings → API → anon public |
+   | `SUPABASE_PROJECT_ID` | Supabase プロジェクトの一意 ID。`npm run db:types` でデータベース型定義を自動生成する際に使用する（ローカル開発でのみ必要） | Supabase Dashboard → Project Settings → General → Reference ID |
+   | `GOOGLE_CALENDAR_IDS` | 取得対象の Google Calendar の ID 一覧（カンマ区切り）。カレンダー連携機能で予定を取得するために使用する | Google Calendar の各カレンダー設定画面（カンマ区切り） |
+   | `GOOGLE_SERVICE_ACCOUNT_KEY` | Google API を呼び出すためのサービスアカウント鍵（JSON 文字列）。カレンダー API への認証に使用する | Google Cloud Console で発行した JSON 鍵の中身（1 行に整形） |
+   | `SLACK_WEBHOOK_URL` | Slack に通知を送るための Incoming Webhook URL。申請・承認イベント等の通知送信先として使用する | Slack の Incoming Webhook 設定画面 |
 
 #### 重要な注意事項
 


### PR DESCRIPTION
## 概要

本番環境リリース手順を GitHub Actions で半自動化する 3 つのワークフローを実装した。手動操作によるヒューマンエラー削減と、誤実行を防ぐ承認ゲート・各種ガード条件の導入が目的。

- 設計書 `docs/ci-cd-design.md` をベースに実装
- リリース PR 作成 → マージ → フォーク同期 + 承認付きタグ／Release 作成、までの一連の流れを自動化

### 関連Issue

- #301

## 技術的変更点

### 新規ワークフロー（3 ファイル）

- `.github/workflows/release-pr.yml`
  - 手動起動 (`workflow_dispatch`) でバージョン番号を受け取り、main を release にマージするための PR を作成
  - 品質ゲート: `build` / `type-check` / `lint` / `test` / `lint:logs` を matrix で並列実行（`fail-fast: false`）
  - `release..main` の差分から、マイグレーションファイル・新規環境変数 (`.env.example` 比較) を検出し、PR 本文に検出結果とマージ前チェックリストを記載
  - `concurrency: release-pr` で同時起動による二重 PR 作成を防止
- `.github/workflows/fork-sync.yml`
  - release への PR マージ後に自動起動（`workflow_dispatch` でも手動実行可）
  - `FORK_SYNC_TOKEN` を使ってフォークリポジトリの `release` ブランチを同期
  - 失敗してもリリース全体はブロックしない（ジョブサマリーに警告出力）
- `.github/workflows/create-release.yml`
  - release への PR マージ後に自動起動
  - ガード条件 5 種: マージ済み / PR タイトル「リリース」開始 / バージョン形式 `X.Y.Z` / タグ重複 / Environment 承認
  - `production-release` Environment の Required reviewers が承認するまで実行を保留
  - `concurrency: create-release` で順序保証

### 設計書・ドキュメント

- `docs/ci-cd-design.md`
  - 3.3 に Variables 一覧 (`SUPABASE_PROJECT_ID`, `FORK_REPO`) を追加
  - 3.4 GitHub Environments セクション新設（`production-release` の設定手順）
  - 4.3 に `create-release.yml` 部分失敗時のリカバリ手順を追加
- `docs/setup.md`
  - `.env.local` 作成手順を `cp .env.example .env.local` に変更
  - 各環境変数の説明・取得元を表形式に整理

### 環境変数設定 (`.env.example` を Git 管理化)

- `.gitignore`: `.env*` の例外として `!.env.example` を追加
- `.env.example` を新規作成。アプリで実際に参照される 6 変数 (`NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` / `SUPABASE_PROJECT_ID` / `GOOGLE_CALENDAR_IDS` / `GOOGLE_SERVICE_ACCOUNT_KEY` / `SLACK_WEBHOOK_URL`) をダミー値・説明コメント付きで記載
- これによりリリース PR の「新規環境変数の検出」が将来的に機能する

### レビュー特記事項

- **マージ前の GitHub 設定が必要**: 以下が未設定だとワークフローが期待どおり動作しません（本 PR マージ前に完了済み）
  - Variable `FORK_REPO`（フォーク同期先 `owner/repo`）
  - Secret `FORK_SYNC_TOKEN`（フォーク側 contents:write 権限の PAT）
  - Environment `production-release`（Required reviewers にリリース承認者を登録、Selected branches に `release` を許可）
- **マージ後にしかテストできない内容**: `workflow_dispatch` はデフォルトブランチに存在する workflow しか UI に出ないため、マージ後の検証が必須。手順は下記「動作確認内容」に記載
- **セキュリティに関する整理**: 既存の `SUPABASE_ACCESS_TOKEN` を悪用すれば本番 Supabase に到達可能なリスクは現状の設定（CODEOWNERS で `.github/workflows/` 保護あり）で残存。ただし本 PR で新たに増えるリスクは無し（追加した 3 ワークフローは `SUPABASE_ACCESS_TOKEN` を参照しない）
- **`.env.example` の Slack URL プレースホルダ**: GitHub secret scanning に誤検出された経緯があり、`your-workspace-id/your-channel-id/your-token` の形式で記載

### TODO事項

- マージ後の検証実施（本 PR 内で完了予定。下記「動作確認内容」参照）
- 必要に応じて Wiki 「本番環境リリース手順」の更新（リリース運用開始時に別途）

## ユニットテスト

- [x] テストの追加・修正は不要

理由: ワークフロー定義 (YAML) およびドキュメント・環境変数サンプルファイルのみで、アプリコードの追加・変更はないため。

## 動作確認内容

### ローカルで完了済み

- YAML 構文チェック: `yaml` パッケージでパース成功を確認（3 ワークフロー全て）
- `.env.example` 検出ロジックのドライラン: `git show` でファイル取得失敗時（両ブランチに `.env.example` 不在のケース）でもスクリプトが正常終了し、結果が「なし」になることを確認
- `.gitignore` 例外の動作確認: `git check-ignore` で `.env.example` が追跡対象となることを確認

### マージ後に GitHub 上で実施予定

> このリストは本 PR マージ後の検証チェックリスト。`workflow_dispatch` が main にしか出現しないため、マージ後に順次実施する。

- [x] **Step A**: `release-pr.yml` を **Version `1.0`（形式違反）** で実行 → `validate-input` で失敗することを確認
- [x] **Step B**: `release-pr.yml` を **Version `99.0.0`（捨て値）** で実行 → 品質チェック 5 種 + PR 作成が成功し、本文に検出結果（初回は 6 変数全てが新規として検出されるはず）が記載されることを確認。確認後 PR は **merge せず Close**
- [x] **Step C**: Step B の PR を Reopen し、`release-pr.yml` を再度起動 → 既存 PR 検出で失敗することを確認後、PR を Close
- [ ] **Step D**: `fork-sync.yml` を `workflow_dispatch` で起動 → フォークの `release` が同期されることを確認
- [x] **Step E**: `create-release.yml` を **Version `99.0.0`** で起動 → `release` ジョブが承認待ちで停止することを確認し、**Reject** してタグが作成されないことを確認
- [ ] **Step F**（本番リリース時に実施）: 実バージョンでエンドツーエンドのリリースを実施

### 検証時の事故対応

誤って `99.0.0` 等の検証用タグが作成された場合:

```bash
git push --delete origin v99.0.0   # リモートタグ削除
git tag -d v99.0.0                 # ローカルタグ削除
gh release delete v99.0.0 --yes    # GitHub Release 削除
```

## その他

- マージ順制約: なし
- 急ぎ度: 標準（本番リリース運用開始のタイミングまでにマージ済みであればよい）