### PR TITLE
fork-sync で fork への push が 403 になる問題を修正

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -52,6 +52,11 @@ jobs:
         with:
           ref: release
           fetch-depth: 0
+          # 既定では checkout が GITHUB_TOKEN（github-actions[bot]）を
+          # http.extraheader として全 github.com URL に永続化する。これは fork remote URL に
+          # 埋め込んだ FORK_SYNC_TOKEN より優先されるため、push が github-actions[bot] 権限で
+          # 実行されフォークへの書き込みが 403 で拒否される。これを防ぐため認証情報を永続化しない。
+          persist-credentials: false
 
       # フォークリポジトリへ release ブランチを push
       - name: フォークリポジトリへ release ブランチを push


### PR DESCRIPTION
## 概要

`fork-sync.yml` を `workflow_dispatch` で実行したところ、「フォークリポジトリへ release ブランチを push」ステップで 403 エラーが発生したため修正する。

```
remote: Permission to soft-regster-for-future-tech/sinlab-portal-site.git denied to github-actions[bot].
fatal: unable to access '...': The requested URL returned error: 403
Error: Process completed with exit code 128.
```

### 関連issue

- #372 
  - PR #372（本番環境リリース自動化ワークフロー）でマージされた `fork-sync.yml` の不具合

## 原因

`actions/checkout` は既定（`persist-credentials: true`）で `GITHUB_TOKEN`（`github-actions[bot]`）を `http.extraheader` としてリポジトリの git config に書き込み、これが **github.com ホスト全体**に適用される。

この `extraheader` の Authorization ヘッダーは、後から追加した fork remote の URL に埋め込んだ `x-access-token:${FORK_SYNC_TOKEN}@` よりも**優先される**。結果として push が `FORK_SYNC_TOKEN` ではなく `github-actions[bot]` の権限で実行され、フォークリポジトリへの書き込みが 403 で拒否されていた。

## 修正内容

checkout ステップに `persist-credentials: false` を追加し、認証情報を永続化しないようにする。これにより fork への push は URL 埋め込みの `FORK_SYNC_TOKEN` を使う。

- release ブランチの clone 自体は一時的に既定トークンを使うため、ブランチ取得には影響しない

## 動作確認

- [x] YAML 構文チェック（`yaml` パッケージでパース成功）
- [ ] **マージ後**: `Fork Sync` を `workflow_dispatch` で再実行し、403 が解消されフォークの `release` ブランチが同期されることを確認

> ⚠️ マージ後の確認で、今度は **トークンのユーザー名**で 403 が出る場合は、`FORK_SYNC_TOKEN` 自体がフォークリポジトリへの `contents:write` 権限を持っているか（Fine-grained PAT なら対象リポジトリに Contents: Read and write、Classic なら `repo` スコープ）を見直す必要がある。

## ユニットテスト

- [x] テストの追加・修正は不要

理由: ワークフロー定義（YAML）のみの変更で、アプリコードの追加・変更はないため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)