### PR TITLE
AIドキュメントにフォーマットチェック手順を追記 (#374)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,7 +64,7 @@
 
 - Issue / PR の目的・完了条件・非対象を明文化してから着手する
 - 要求範囲に対して最小差分で実装し、無関係な変更を混ぜない
-- 変更後は `npm run lint` → `npm run type-check` → `npm run build` → `npm run format:check` を順に実行する
+- 変更後は `npm run lint` → `npm run type-check` → `npm run format:check` → `npm run build` を順に実行する（ビルド前に整形差分を検知する）
 - `npm run format:check` で整形差分が検出された場合は、`npm run format` を実行して整形を適用し、整形差分を含めてコミットする
 
 ## レビュー観点
@@ -101,5 +101,5 @@ Copilot レビューは次の優先順位で指摘する。
 
 1. `npm run lint`
 2. `npm run type-check`
-3. `npm run build`
-4. `npm run format:check`
+3. `npm run format:check`
+4. `npm run build`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,7 +64,8 @@
 
 - Issue / PR の目的・完了条件・非対象を明文化してから着手する
 - 要求範囲に対して最小差分で実装し、無関係な変更を混ぜない
-- 変更後は `npm run lint` → `npm run type-check` → `npm run build` を順に実行する
+- 変更後は `npm run lint` → `npm run type-check` → `npm run build` → `npm run format:check` を順に実行する
+- `npm run format:check` で整形差分が検出された場合は、`npm run format` を実行して整形を適用し、整形差分を含めてコミットする
 
 ## レビュー観点
 
@@ -101,3 +102,4 @@ Copilot レビューは次の優先順位で指摘する。
 1. `npm run lint`
 2. `npm run type-check`
 3. `npm run build`
+4. `npm run format:check`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,10 +99,12 @@ npm run db:types   # Supabase型生成
 
 コード変更を行った後、以下のチェックを順番に実行し、すべて通ることを確認する。エラーがあれば修正してから完了とする。
 
+ビルド前にフォーマット起因の差分を解消するため、`npm run format:check` を `npm run build` より先に実行する。
+
 1. `npm run lint` - ESLintチェック
 2. `npm run type-check` - 型チェック
-3. `npm run build` - ビルドチェック
-4. `npm run format:check` - Prettierフォーマットチェック
+3. `npm run format:check` - Prettierフォーマットチェック
+4. `npm run build` - ビルドチェック
 
 `npm run format:check` で整形差分が検出された場合は、`npm run format` を実行して整形を適用し、整形差分を含めてコミットする。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ npm run dev        # 開発サーバー（Turbopack）
 npm run build      # 本番ビルド
 npm run lint       # ESLint
 npm run type-check # 型チェック（tsc --noEmit）
+npm run format:check # Prettierフォーマットチェック
+npm run format     # Prettierフォーマット適用
 npm run db:types   # Supabase型生成
 ```
 
@@ -100,6 +102,9 @@ npm run db:types   # Supabase型生成
 1. `npm run lint` - ESLintチェック
 2. `npm run type-check` - 型チェック
 3. `npm run build` - ビルドチェック
+4. `npm run format:check` - Prettierフォーマットチェック
+
+`npm run format:check` で整形差分が検出された場合は、`npm run format` を実行して整形を適用し、整形差分を含めてコミットする。
 
 ## 禁止事項
 


### PR DESCRIPTION
## 概要

- AI Agent 利用時の手順として、フォーマットチェックを開発フローに明示しました。
- `npm run format:check` で整形差分が検出された場合に、`npm run format` を実行して整形差分をコミットに含める運用を追記しました。
- Wiki 側（portal-site.wiki）にも反映し、`format:check` を `build` より前に実行する順序へ統一しました。

### 関連Issue

- #374

## 技術的変更点

- `.github/copilot-instructions.md`
  - 実装後チェックの手順を `lint -> type-check -> format:check -> build` の順に更新
  - `format:check` で差分検出時に `format` 実行・整形差分をコミットに含める方針を追記
- `CLAUDE.md`
  - 開発コマンド一覧へ `npm run format:check` / `npm run format` を明記
  - 実装後チェックに `npm run format:check` を追加
  - `format:check` で差分検出時の対応方針を追記
- [Github Copilotガイド](https://github.com/Singuralitylabs/portal-site/wiki/Github-Copilot%E3%82%AC%E3%82%A4%E3%83%89)
  - 確認コマンド順を `lint / type-check / format:check / build` に更新
  - レビューフローの実行順を `npm run lint -> npm run type-check -> npm run format:check -> npm run build` に更新
  - 生成プロンプト例の報告順を `lint/type-check/format:check/build` に更新
- [Claude Code ガイド](https://github.com/Singuralitylabs/portal-site/wiki/Claude-Code-%E3%82%AC%E3%82%A4%E3%83%89)
  - 実装後の実行順を「lint・型チェック・フォーマットチェック・ビルド」に更新

### レビュー特記事項

- Issue 本文上の `copilot-instruction.md` は実ファイル名と異なるため、実際の対象である `.github/copilot-instructions.md` を更新しています。
- アプリケーションコード（機能実装）の変更はありません。
- Wiki 反映は `portal-site.wiki` 側で実施済みです。

### TODO事項

- なし

## ユニットテスト

- [x] テストの追加・修正は不要
- [ ] テストを追加・修正した

## 動作確認内容

- [x] PR差分がドキュメント2ファイルのみであることを確認
  - `.github/copilot-instructions.md`
  - `CLAUDE.md`
- [x] GitHub Actions の Format Check が成功していることを確認
  - `Format Check/Prettier Format Check (22.x) (push)`
  - `Format Check/Prettier Format Check (22.x) (pull_request)`
- [x] `npm run lint`
  - 結果: 成功（既存 warning のみ）
- [x] `npm run type-check`
  - 結果: 成功
- [x] `npm run format:check`
  - 結果: 成功（All matched files use Prettier code style）
- [x] `npm run build`
  - 結果: 成功（既存 warning のみ）

## その他

- なし

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
