### PR TITLE
test: Jest失敗を最小修正で解消（profile_image_pathモック追従）

### DIFF
--- a/tests/services/api/supabase-server.test.ts
+++ b/tests/services/api/supabase-server.test.ts
@@ -254,6 +254,7 @@ describe("server API services", () => {
             display_name: "user",
             bio: "bio",
             avatar_url: "a",
+            profile_image_path: null,
             x_url: null,
             facebook_url: null,
             instagram_url: null,


### PR DESCRIPTION
## 概要

`feature/add-profile-image` で発生していた Jest 失敗を、最小差分で解消するための修正です。

- `fetchActiveUsers` のテストデータに `profile_image_path` を追加し、実装変更後のデータ形に合わせました。

### 関連Issue

- #252

## 技術的変更点

- 変更ファイル: `tests/services/api/supabase-server.test.ts`
- 変更内容:
  - `fetchActiveUsers: 正常系で変換済みデータを返す` のモックデータに `profile_image_path: null` を追加
- 変更意図:
  - `app/services/api/users-server.ts` 側で `profile_image_path` を前提に `supabase.storage.from("profile-images").createSignedUrls(...)` を扱う実装が追加されたため、テストモックのデータ形を実装に追従させる

### レビュー特記事項

- 問題だった箇所:
  - `tests/services/api/supabase-server.test.ts` の `fetchActiveUsers` 正常系
  - 旧モックが `profile_image_path` を持たず、実装側の処理と乖離して CI で `TypeError: Cannot read properties of undefined (reading 'from')` が発生
- 改善方法:
  - テスト側の入力データを実装仕様に合わせ、`profile_image_path` を明示してモック整合性を回復
  - 影響範囲をテスト1箇所・1行追加に限定し、最小修正で復旧

### TODO事項

- 今回はCI復旧を優先し、最小修正のみ実施
- `fetchActiveUsers` の `profile_image_path` null/非null での `profile_image_url` 変換検証ケース拡充は別PRで検討

## ユニットテスト

- [ ] テストの追加・修正は不要
- [x] テストを追加・修正した

## 動作確認内容

- GitHub Actions `Jest Unit Tests` 実行結果を確認
  - 対象Run: https://github.com/Singuralitylabs/portal-site/actions/runs/27015025688/
  - 結果: `success`
  - ジョブ: `test` / `Run Jest tests` ステップ成功

## その他

- `feature/add-profile-image` 向けのエラー修正提案PRです。

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語を使ってください。 -->
