### PR TITLE
[Environment] GitHub Actions の checkout/setup-node を v5 に更新（Node.js 20 非推奨対応） (#384)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/check_console_log.yml
+++ b/.github/workflows/check_console_log.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: "npm"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -73,7 +73,7 @@ jobs:
 
       # タグ重複チェックのため release ブランチをチェックアウト（タグ情報も取得）
       - name: Checkout release branch with tags
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: release
           fetch-depth: 0
@@ -181,7 +181,7 @@ jobs:
     steps:
       # validate ジョブで確定した SHA をチェックアウト（release ブランチ HEAD ではなく固定 SHA）
       - name: Checkout target commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.validate.outputs.target_sha }}
           fetch-depth: 0

--- a/.github/workflows/db-types.yml
+++ b/.github/workflows/db-types.yml
@@ -36,11 +36,11 @@ jobs:
     steps:
       # リポジトリのソースコードをワークフロー実行環境へ取得
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Supabase CLI実行に必要なNode.js実行環境を準備
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: "npm"

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -48,7 +48,7 @@ jobs:
       # 浅い clone だと fast-forward 判定ができず push が拒否される場合があるため fetch-depth: 0 とする。
       # 本ステップは release ブランチのみを対象とし、タグは push しない）
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: release
           fetch-depth: 0

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -53,12 +53,12 @@ jobs:
         task: [build, type-check, lint, test, lint:logs]
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: "npm"
@@ -91,7 +91,7 @@ jobs:
     steps:
       # release / main 両ブランチの履歴を遡るため全履歴を取得
       - name: Checkout repository (full history)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       # ソースコード取得
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Node.js セットアップ
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: "npm"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"


### PR DESCRIPTION
## 概要

<!-- 変更の背景・理由と、変更の概要を記載してください -->

- GitHub Actions のジョブ実行時に `actions/checkout@v4` / `actions/setup-node@v4` が Node.js 20 で動作しているため非推奨警告が出ている（2026年9月16日にランナーから Node.js 20 が削除予定）
- 全ワークフローのアクションバージョンを Node 24 対応の v5 に更新

### 関連Issue

- #384

## 技術的変更点

- `.github/workflows/` 配下の全9ワークフローを更新
  - `actions/checkout@v4` → `@v5`（11箇所）
  - `actions/setup-node@v4` → `@v5`（7箇所）
- Issue記載の対象（8ファイル・10箇所）に加え、Issue作成後に追加された `format-check.yml`（#378）も対象に含めた

### レビュー特記事項

- バージョンは Issue の完了条件「@v5 以上」を満たす v5 を選択。v5 は Node 24 対応のランタイム更新が主で、挙動変更が最小のため（最新の v6 系は採用見送り）

### TODO事項

- なし

## ユニットテスト

- [x] テストの追加・修正は不要
- [ ] テストを追加・修正した

## 動作確認内容

- `npm run format:check` 通過（CI設定のYAMLのみの変更のため）
- 各ワークフローの正常動作は本PRのActions実行結果で確認する

## その他

- なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)